### PR TITLE
Use NULL for validator columns; add upgrader.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,3 @@
+Development:
+  - t_validators table no longer uses '-1' as an indicator for the Ethereum spec value `FAR_FUTURE_EPOCH`, instead it uses NULL
+  - add upgrader to update the database schema when changes are made

--- a/main.go
+++ b/main.go
@@ -176,6 +176,11 @@ func startServices(ctx context.Context) error {
 		return errors.Wrap(err, "failed to start chain database service")
 	}
 
+	log.Trace().Msg("Checking for schema upgrades")
+	if err := chainDB.Upgrade(ctx); err != nil {
+		return errors.Wrap(err, "failed to upgrade chain database")
+	}
+
 	log.Trace().Msg("Starting Ethereum 2 client service")
 	eth2Client, err := fetchClient(ctx, viper.GetString("eth2client.address"))
 	if err != nil {

--- a/schema.sql
+++ b/schema.sql
@@ -14,10 +14,10 @@ CREATE TABLE t_validators (
   f_public_key                   BYTEA NOT NULL
  ,f_index                        BIGINT NOT NULL
  ,f_slashed                      BOOLEAN NOT NULL
- ,f_activation_eligibility_epoch BIGINT NOT NULL
- ,f_activation_epoch             BIGINT NOT NULL
- ,f_exit_epoch                   BIGINT NOT NULL
- ,f_withdrawable_epoch           BIGINT NOT NULL
+ ,f_activation_eligibility_epoch BIGINT
+ ,f_activation_epoch             BIGINT
+ ,f_exit_epoch                   BIGINT
+ ,f_withdrawable_epoch           BIGINT
  ,f_effective_balance            BIGINT NOT NULL
 );
 CREATE UNIQUE INDEX i_validators_1 ON t_validators(f_index);

--- a/services/beaconcommittees/standard/parameters.go
+++ b/services/beaconcommittees/standard/parameters.go
@@ -94,11 +94,11 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	// Ensure the eth2client can handle our requirements.
 	if _, isProvider := parameters.eth2Client.(eth2client.BeaconCommitteesProvider); !isProvider {
 		//nolint:stylecheck
-		return nil, errors.New("Ethereum 2 client does not provide beacon committee information")
+		return nil, errors.New("Ethereum 2 client does not provide beacon committee information") // skipcq: SCC-ST1005
 	}
 	if _, isProvider := parameters.eth2Client.(eth2client.EventsProvider); !isProvider {
 		//nolint:stylecheck
-		return nil, errors.New("Ethereum 2 client does not provide events")
+		return nil, errors.New("Ethereum 2 client does not provide events") // skipcq: SCC-ST1005
 	}
 	if parameters.chainDB == nil {
 		return nil, errors.New("no chain database specified")

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -1,0 +1,150 @@
+// Copyright © 2021 Weald Technology Trading.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+type schemaMetadata struct {
+	Version uint64 `json:"version"`
+}
+
+var currentVersion = uint64(1)
+
+var upgradeFunctions = map[uint64][]func(context.Context, *Service) error{
+	1: {
+		validatorsEpochNull,
+	},
+}
+
+// Upgrade upgrades the database.
+func (s *Service) Upgrade(ctx context.Context) error {
+	version, err := s.version(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to obtain version")
+	}
+
+	if version == currentVersion {
+		// Nothing to do.
+		return nil
+	}
+
+	ctx, cancel, err := s.BeginTx(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin upgrade transaction")
+	}
+
+	for i := version; i <= currentVersion; i++ {
+		if upgradeFuncs, exists := upgradeFunctions[i]; exists {
+			for _, upgradeFunc := range upgradeFuncs {
+				if err := upgradeFunc(ctx, s); err != nil {
+					cancel()
+					return errors.Wrap(err, "failed to upgrade")
+				}
+			}
+		}
+	}
+
+	if err := s.setVersion(ctx, currentVersion); err != nil {
+		cancel()
+		return errors.Wrap(err, "failed to set latest schema version")
+	}
+
+	if err := s.CommitTx(ctx); err != nil {
+		cancel()
+		return errors.Wrap(err, "failed to commit upgrade transaction")
+	}
+
+	return nil
+}
+
+// validatorsEpochNull allows epochs in the t_validators table to be NULL.
+func validatorsEpochNull(ctx context.Context, s *Service) error {
+	tx := s.tx(ctx)
+	if tx == nil {
+		return ErrNoTransaction
+	}
+
+	// Drop NOT NULL constraints.
+	if _, err := tx.Exec(ctx, "ALTER TABLE t_validators ALTER COLUMN f_activation_eligibility_epoch DROP NOT NULL"); err != nil {
+		return errors.Wrap(err, "failed to drop NOT NULL constraint on f_activation_eligibility_epoch")
+	}
+	if _, err := tx.Exec(ctx, "ALTER TABLE t_validators ALTER COLUMN f_activation_epoch DROP NOT NULL"); err != nil {
+		return errors.Wrap(err, "failed to drop NOT NULL constraint on f_activation_epoch")
+	}
+	if _, err := tx.Exec(ctx, "ALTER TABLE t_validators ALTER COLUMN f_exit_epoch DROP NOT NULL"); err != nil {
+		return errors.Wrap(err, "failed to drop NOT NULL constraint on f_exit_epoch")
+	}
+	if _, err := tx.Exec(ctx, "ALTER TABLE t_validators ALTER COLUMN f_withdrawable_epoch DROP NOT NULL"); err != nil {
+		return errors.Wrap(err, "failed to drop NOT NULL constraint on f_withdrawable_epoch")
+	}
+
+	// Change -1 values to NULL.
+	if _, err := tx.Exec(ctx, "UPDATE t_validators SET f_activation_eligibility_epoch = NULL WHERE f_activation_eligibility_epoch = -1"); err != nil {
+		return errors.Wrap(err, "failed to change -1 to NULL on f_activation_eligibility_epoch")
+	}
+	if _, err := tx.Exec(ctx, "UPDATE t_validators SET f_activation_epoch = NULL WHERE f_activation_epoch = -1"); err != nil {
+		return errors.Wrap(err, "failed to change -1 to NULL on f_activation_epoch")
+	}
+	if _, err := tx.Exec(ctx, "UPDATE t_validators SET f_exit_epoch = NULL WHERE f_exit_epoch = -1"); err != nil {
+		return errors.Wrap(err, "failed to change -1 to NULL on f_exit_epoch")
+	}
+	if _, err := tx.Exec(ctx, "UPDATE t_validators SET f_withdrawable_epoch = NULL WHERE f_withdrawable_epoch = -1"); err != nil {
+		return errors.Wrap(err, "failed to change -1 to NULL on f_withdrawable_epoch")
+	}
+
+	return nil
+}
+
+// version obtains the version of the schema.
+func (s *Service) version(ctx context.Context) (uint64, error) {
+	data, err := s.Metadata(ctx, "schema")
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to obtain schema metadata")
+	}
+
+	// No data means it's version 0 of the schema.
+	if len(data) == 0 {
+		return 0, nil
+	}
+
+	var metadata schemaMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return 0, errors.Wrap(err, "failed to unmarshal metadata JSON")
+	}
+
+	return metadata.Version, nil
+}
+
+// setVersion sets the version of the schema.
+func (s *Service) setVersion(ctx context.Context, version uint64) error {
+	tx := s.tx(ctx)
+	if tx == nil {
+		return ErrNoTransaction
+	}
+
+	metadata := &schemaMetadata{
+		Version: version,
+	}
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal metadata")
+	}
+
+	return s.SetMetadata(ctx, "schema", data)
+}

--- a/services/chaindb/postgresql/validators_test.go
+++ b/services/chaindb/postgresql/validators_test.go
@@ -1,0 +1,87 @@
+// Copyright © 2021 Weald Technology Trading.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+	"github.com/wealdtech/chaind/services/chaindb"
+	"github.com/wealdtech/chaind/services/chaindb/postgresql"
+)
+
+func TestSetValidators(t *testing.T) {
+	ctx := context.Background()
+	s, err := postgresql.New(ctx,
+		postgresql.WithConnectionURL(os.Getenv("CHAINDB_DATABASE_URL")),
+	)
+	require.NoError(t, err)
+
+	validator1 := &chaindb.Validator{
+		PublicKey: spec.BLSPubKey{
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		Index:                      1,
+		EffectiveBalance:           32000000000,
+		Slashed:                    false,
+		ActivationEligibilityEpoch: 1,
+		ActivationEpoch:            2,
+		ExitEpoch:                  3,
+		WithdrawableEpoch:          4,
+	}
+	validator2 := &chaindb.Validator{
+		PublicKey: spec.BLSPubKey{
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		},
+		Index:                      2,
+		EffectiveBalance:           0,
+		Slashed:                    false,
+		ActivationEligibilityEpoch: 0xffffffffffffffff,
+		ActivationEpoch:            0xffffffffffffffff,
+		ExitEpoch:                  0xffffffffffffffff,
+		WithdrawableEpoch:          0xffffffffffffffff,
+	}
+
+	// Attempt to set the validator without a transaction; should fail.
+	require.Error(t, s.SetValidator(ctx, validator1))
+
+	ctx, cancel, err := s.BeginTx(ctx)
+	require.NoError(t, err)
+	defer cancel()
+
+	// Set the validator.
+	require.NoError(t, s.SetValidator(ctx, validator1))
+	// Update the validator.
+	require.NoError(t, s.SetValidator(ctx, validator1))
+
+	// Ensure the correct data is returned.
+	res, err := s.ValidatorsByPublicKey(ctx, []spec.BLSPubKey{validator1.PublicKey})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, validator1, res[validator1.PublicKey])
+
+	// Ensure that validator with far future epoch values is stored and returned.
+	require.NoError(t, s.SetValidator(ctx, validator2))
+	res, err = s.ValidatorsByPublicKey(ctx, []spec.BLSPubKey{validator2.PublicKey})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, validator2, res[validator2.PublicKey])
+}


### PR DESCRIPTION
V1 of chaind used '-1' to mark a validator epoch column as
FAR_FUTURE_EPOCH.  The actual value of FAR_FUTURE_EPOCH is not
compatible with the PostgreSQL 'BIGINT' column, as it is outside of its
range.  Although -1 worked, it made querying the database harder than it
needed to be with multiple constraints, and could cause confusion with
differing definitions of the conditions for states.

This change alters the schema of t_validators to allow NULL values in
the relevant columns, and updates existing values of FAR_FUTURE_EPOCH to
be NULL.

This change also introduces a generic database upgrader, which is used
to carry out the required changes to the database schema and data.  The
upgrader can be used for additional changes in the schema as V2
progresses.