### PR TITLE
Add parameter tables.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 Development:
+  - add t_chain_spec table, holding the chain specification
+  - add t_genesis table, holding the chain genesis information
   - add t_deposits table, holding Ethereum 1 deposits recognized on the beacon chain and provided in the beacon block
   - t_validators table no longer uses '-1' as an indicator for the Ethereum spec value `FAR_FUTURE_EPOCH`, instead it uses NULL
   - add upgrader to update the database schema when changes are made

--- a/schema.sql
+++ b/schema.sql
@@ -5,6 +5,23 @@ CREATE TABLE t_metadata (
  ,f_value JSONB NOT NULL
 );
 CREATE UNIQUE INDEX i_metadata_1 ON t_metadata(f_key);
+INSERT INTO t_metadata VALUES('schema', '{"version": 1}');
+
+-- t_chain_spec contains the specification of the chain to which the rest of
+-- the tables relate.
+DROP TABLE IF EXISTS t_chain_spec CASCADE;
+CREATE TABLE t_chain_spec (
+  f_key TEXT NOT NULL PRIMARY KEY
+ ,f_value TEXT NOT NULL
+);
+
+-- t_genesis contains the genesis parameters of the chain.
+DROP TABLE IF EXISTS t_genesis CASCADE;
+CREATE TABLE t_genesis (
+  f_validators_root BYTEA NOT NULL PRIMARY KEY
+ ,f_time TIMESTAMPTZ NOT NULL
+ ,f_fork_version BYTEA NOT NULL
+);
 
 -- t_validators contains all validators known by the chain.
 -- This information is not stored per-epoch, as the latest values contain the

--- a/services/chaindb/postgresql/chainspec.go
+++ b/services/chaindb/postgresql/chainspec.go
@@ -1,0 +1,185 @@
+// Copyright © 2021 Weald Technology Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+)
+
+// SetChainSpecValue sets the value of the provided key.
+func (s *Service) SetChainSpecValue(ctx context.Context, key string, value interface{}) error {
+	tx := s.tx(ctx)
+	if tx == nil {
+		return ErrNoTransaction
+	}
+
+	var dbVal string
+	switch v := value.(type) {
+	case spec.Slot, spec.Epoch, spec.CommitteeIndex, spec.ValidatorIndex, spec.Gwei:
+		dbVal = fmt.Sprintf("%d", v)
+	case spec.Root, spec.Version, spec.DomainType, spec.ForkDigest, spec.Domain, spec.BLSPubKey, spec.BLSSignature, []byte:
+		dbVal = fmt.Sprintf("%#x", v)
+	case time.Duration:
+		dbVal = fmt.Sprintf("%d", int(v.Seconds()))
+	case time.Time:
+		dbVal = fmt.Sprintf("%d", v.Unix())
+	default:
+		dbVal = fmt.Sprintf("%v", v)
+	}
+	_, err := tx.Exec(ctx, `
+      INSERT INTO t_chain_spec(f_key
+                              ,f_value)
+      VALUES($1,$2)
+      ON CONFLICT (f_key) DO
+      UPDATE
+      SET f_value = excluded.f_value
+      `,
+		key,
+		dbVal,
+	)
+
+	return err
+}
+
+// ChainSpec fetches all chain specification values.
+func (s *Service) ChainSpec(ctx context.Context) (map[string]interface{}, error) {
+	tx := s.tx(ctx)
+	if tx == nil {
+		ctx, cancel, err := s.BeginTx(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to begin transaction")
+		}
+		tx = s.tx(ctx)
+		defer cancel()
+	}
+
+	spec := make(map[string]interface{})
+	rows, err := tx.Query(ctx, `
+      SELECT f_key
+            ,f_value
+      FROM t_chain_spec
+	  `)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var key string
+		var dbVal string
+		err := rows.Scan(
+			&key,
+			&dbVal,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan row")
+		}
+
+		spec[key] = dbValToSpec(ctx, key, dbVal)
+	}
+
+	return spec, nil
+}
+
+// ChainSpecValue fetches a chain specification value given its key.
+func (s *Service) ChainSpecValue(ctx context.Context, key string) (interface{}, error) {
+	tx := s.tx(ctx)
+	if tx == nil {
+		ctx, cancel, err := s.BeginTx(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to begin transaction")
+		}
+		tx = s.tx(ctx)
+		defer cancel()
+	}
+
+	var dbVal string
+	err := tx.QueryRow(ctx, `
+      SELECT f_value
+      FROM t_chain_spec
+	  WHERE f_key = $1
+	  `, key).Scan(&dbVal)
+	if err != nil {
+		return nil, err
+	}
+
+	return dbValToSpec(ctx, key, dbVal), nil
+}
+
+// dbValToSpec turns a database value in to a spec value.
+func dbValToSpec(ctx context.Context, key string, val string) interface{} {
+	// Handle domains.
+	if strings.HasPrefix(key, "DOMAIN_") {
+		byteVal, err := hex.DecodeString(strings.TrimPrefix(val, "0x"))
+		if err == nil {
+			var domainType spec.DomainType
+			copy(domainType[:], byteVal)
+			return domainType
+		}
+	}
+
+	// Handle fork versions.
+	if strings.HasSuffix(key, "_FORK_VERSION") {
+		byteVal, err := hex.DecodeString(strings.TrimPrefix(val, "0x"))
+		if err == nil {
+			var version spec.Version
+			copy(version[:], byteVal)
+			return version
+		}
+	}
+
+	// Handle hex strings.
+	if strings.HasPrefix(val, "0x") {
+		byteVal, err := hex.DecodeString(strings.TrimPrefix(val, "0x"))
+		if err == nil {
+			return byteVal
+		}
+	}
+
+	// Handle times.
+	if strings.HasSuffix(key, "_TIME") {
+		intVal, err := strconv.ParseInt(val, 10, 64)
+		if err == nil && intVal != 0 {
+			return time.Unix(intVal, 0)
+		}
+	}
+
+	// Handle durations.
+	if strings.HasPrefix(key, "SECONDS_PER_") {
+		intVal, err := strconv.ParseUint(val, 10, 64)
+		if err == nil && intVal != 0 {
+			return time.Duration(intVal) * time.Second
+		}
+	}
+
+	// Handle integers.
+	if val == "0" {
+		return uint64(0)
+	}
+	intVal, err := strconv.ParseUint(val, 10, 64)
+	if err == nil && intVal != 0 {
+		return intVal
+	}
+
+	// Assume string.
+	return val
+}

--- a/services/chaindb/postgresql/chainspec_test.go
+++ b/services/chaindb/postgresql/chainspec_test.go
@@ -1,0 +1,117 @@
+// Copyright © 2021 Weald Technology Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"github.com/wealdtech/chaind/services/chaindb/postgresql"
+)
+
+func TestSetChainSpecValue(t *testing.T) {
+	ctx := context.Background()
+	s, err := postgresql.New(ctx,
+		postgresql.WithLogLevel(zerolog.Disabled),
+		postgresql.WithConnectionURL(os.Getenv("CHAINDB_DATABASE_URL")),
+	)
+	require.NoError(t, err)
+
+	// Try to set outside of a transaction; should fail.
+	require.EqualError(t, s.SetChainSpecValue(ctx, "TEST_VALUE", "1"), postgresql.ErrNoTransaction.Error())
+
+	ctx, cancel, err := s.BeginTx(ctx)
+	require.NoError(t, err)
+	defer cancel()
+
+	// Set a value.
+	require.NoError(t, s.SetChainSpecValue(ctx, "SECONDS_PER_MINUTE", 59*time.Second))
+
+	// Attempt to set the same deposit again; should succeed.
+	require.NoError(t, s.SetChainSpecValue(ctx, "SECONDS_PER_MINUTE", 60*time.Second))
+}
+
+func TestChainSpec(t *testing.T) {
+	ctx := context.Background()
+	s, err := postgresql.New(ctx,
+		postgresql.WithLogLevel(zerolog.Disabled),
+		postgresql.WithConnectionURL(os.Getenv("CHAINDB_DATABASE_URL")),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel, err := s.BeginTx(ctx)
+	require.NoError(t, err)
+	defer cancel()
+
+	tests := []struct {
+		name string
+		key  string
+		val  interface{}
+	}{
+		{
+			name: "Duration",
+			key:  "SECONDS_PER_MINUTE",
+			val:  60 * time.Second,
+		},
+		{
+			name: "Integer",
+			key:  "IntegerVal",
+			val:  uint64(12345),
+		},
+		{
+			name: "String",
+			key:  "NAME",
+			val:  "mainnet",
+		},
+		{
+			name: "Domain",
+			key:  "DOMAIN_VOLUNTARY_EXIT",
+			val:  spec.DomainType{0x01, 0x02, 0x03, 0x04},
+		},
+		{
+			name: "ForkVersion",
+			key:  "GENESIS_FORK_VERSION",
+			val:  spec.Version{0x01, 0x02, 0x03, 0x04},
+		},
+		{
+			name: "Hex",
+			key:  "GENERIC_HEX_STRING",
+			val:  []byte{0x01, 0x02, 0x03, 0x04},
+		},
+		{
+			name: "Time",
+			key:  "GENESIS_TIME",
+			val:  time.Unix(1600000000, 0),
+		},
+	}
+
+	// Set the values.
+	for _, test := range tests {
+		require.NoError(t, s.SetChainSpecValue(ctx, test.key, test.val))
+	}
+
+	// Fetch the values
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			val, err := s.ChainSpecValue(ctx, test.key)
+			require.NoError(t, err)
+			require.Equal(t, test.val, val)
+		})
+	}
+}

--- a/services/chaindb/postgresql/genesis.go
+++ b/services/chaindb/postgresql/genesis.go
@@ -1,0 +1,90 @@
+// Copyright © 2021 Weald Technology Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql
+
+import (
+	"context"
+	"time"
+
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/pkg/errors"
+)
+
+// SetGenesis sets the genesis information.
+func (s *Service) SetGenesis(ctx context.Context, genesis *api.Genesis) error {
+	tx := s.tx(ctx)
+	if tx == nil {
+		return ErrNoTransaction
+	}
+
+	_, err := tx.Exec(ctx, `
+      INSERT INTO t_genesis(f_validators_root
+                           ,f_time
+                           ,f_fork_version)
+      VALUES($1,$2,$3)
+      ON CONFLICT (f_validators_root) DO
+      UPDATE
+      SET f_time = excluded.f_time
+         ,f_fork_version = excluded.f_fork_version
+      `,
+		genesis.GenesisValidatorsRoot[:],
+		genesis.GenesisTime,
+		genesis.GenesisForkVersion[:],
+	)
+
+	return err
+}
+
+// Genesis fetches genesis values.
+func (s *Service) Genesis(ctx context.Context) (*api.Genesis, error) {
+	tx := s.tx(ctx)
+	if tx == nil {
+		ctx, cancel, err := s.BeginTx(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to begin transaction")
+		}
+		tx = s.tx(ctx)
+		defer cancel()
+	}
+
+	genesis := &api.Genesis{}
+	var genesisValidatorsRoot []byte
+	var genesisForkVersion []byte
+	err := tx.QueryRow(ctx, `
+      SELECT f_validators_root
+            ,f_time
+            ,f_fork_version
+      FROM t_genesis
+	  `).Scan(
+		&genesisValidatorsRoot,
+		&genesis.GenesisTime,
+		&genesisForkVersion,
+	)
+	if err != nil {
+		return nil, err
+	}
+	copy(genesis.GenesisValidatorsRoot[:], genesisValidatorsRoot)
+	copy(genesis.GenesisForkVersion[:], genesisForkVersion)
+
+	return genesis, nil
+}
+
+// GenesisTime provides the genesis time of the chain.
+func (s *Service) GenesisTime(ctx context.Context) (time.Time, error) {
+	genesis, err := s.Genesis(ctx)
+	if err != nil {
+		return time.Time{}, errors.Wrap(err, "failed to obtain genesis")
+	}
+	return genesis.GenesisTime, nil
+}

--- a/services/chaindb/postgresql/genesis_test.go
+++ b/services/chaindb/postgresql/genesis_test.go
@@ -1,0 +1,81 @@
+// Copyright © 2021 Weald Technology Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"github.com/wealdtech/chaind/services/chaindb"
+	"github.com/wealdtech/chaind/services/chaindb/postgresql"
+)
+
+func TestSetGenesis(t *testing.T) {
+	ctx := context.Background()
+	s, err := postgresql.New(ctx,
+		postgresql.WithLogLevel(zerolog.Disabled),
+		postgresql.WithConnectionURL(os.Getenv("CHAINDB_DATABASE_URL")),
+	)
+	require.NoError(t, err)
+
+	genesis := &api.Genesis{
+		GenesisTime: time.Unix(1600000000, 0),
+		GenesisValidatorsRoot: spec.Root{
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		GenesisForkVersion: spec.Version{0x00, 0x01, 0x02, 0x03},
+	}
+
+	// Try to set outside of a transaction; should fail.
+	require.EqualError(t, s.SetGenesis(ctx, genesis), postgresql.ErrNoTransaction.Error())
+
+	ctx, cancel, err := s.BeginTx(ctx)
+	require.NoError(t, err)
+	defer cancel()
+
+	// Set.
+	require.NoError(t, s.SetGenesis(ctx, genesis))
+
+	// Attempt to set again; should succeed.
+	require.NoError(t, s.SetGenesis(ctx, genesis))
+}
+
+func TestGenesisTime(t *testing.T) {
+	ctx := context.Background()
+
+	var s chaindb.Service
+	var err error
+	s, err = postgresql.New(ctx,
+		postgresql.WithLogLevel(zerolog.Disabled),
+		postgresql.WithConnectionURL(os.Getenv("CHAINDB_DATABASE_URL")),
+	)
+	require.NoError(t, err)
+
+	// Ensure this meets the eth2client interface requirement.
+	_, isProvider := s.(eth2client.GenesisTimeProvider)
+	require.True(t, isProvider)
+
+	// Ensure the value
+	genesisTime, err := s.(eth2client.GenesisTimeProvider).GenesisTime(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, genesisTime)
+}

--- a/services/chaindb/postgresql/spec.go
+++ b/services/chaindb/postgresql/spec.go
@@ -1,0 +1,47 @@
+// Copyright © 2021 Weald Technology Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// SlotDuration provides the duration of a slot of the chain.
+func (s *Service) SlotDuration(ctx context.Context) (time.Duration, error) {
+	val, err := s.ChainSpecValue(ctx, "SECONDS_PER_SLOT")
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to obtain SECONDS_PER_SLOT")
+	}
+	specVal, ok := val.(time.Duration)
+	if !ok {
+		return 0, errors.New("invalid type for SECONDS_PER_SLOT")
+	}
+	return specVal, nil
+}
+
+// SlotsPerEpoch provides the slots per epoch of the chain.
+func (s *Service) SlotsPerEpoch(ctx context.Context) (uint64, error) {
+	val, err := s.ChainSpecValue(ctx, "SLOTS_PER_EPOCH")
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to obtain SLOTS_PER_EPOCH")
+	}
+	specVal, ok := val.(uint64)
+	if !ok {
+		return 0, errors.New("invalid type for SLOTS_PER_EPOCH")
+	}
+	return specVal, nil
+}

--- a/services/chaindb/postgresql/spec_test.go
+++ b/services/chaindb/postgresql/spec_test.go
@@ -1,0 +1,71 @@
+// Copyright © 2021 Weald Technology Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"github.com/wealdtech/chaind/services/chaindb"
+	"github.com/wealdtech/chaind/services/chaindb/postgresql"
+)
+
+func TestSlotDuration(t *testing.T) {
+	ctx := context.Background()
+
+	var s chaindb.Service
+	var err error
+	s, err = postgresql.New(ctx,
+		postgresql.WithLogLevel(zerolog.Disabled),
+		postgresql.WithConnectionURL(os.Getenv("CHAINDB_DATABASE_URL")),
+	)
+	require.NoError(t, err)
+
+	// Ensure this meets the eth2client interface requirement.
+	_, isProvider := s.(eth2client.SlotDurationProvider)
+	require.True(t, isProvider)
+
+	// Ensure the value.
+	slotDuration, err := s.(eth2client.SlotDurationProvider).SlotDuration(ctx)
+	require.NoError(t, err)
+	// This is hard-coded to the common value; may fail on non-standard chains.
+	require.Equal(t, 12*time.Second, slotDuration)
+}
+
+func TestSlotsPerEpoch(t *testing.T) {
+	ctx := context.Background()
+
+	var s chaindb.Service
+	var err error
+	s, err = postgresql.New(ctx,
+		postgresql.WithLogLevel(zerolog.Disabled),
+		postgresql.WithConnectionURL(os.Getenv("CHAINDB_DATABASE_URL")),
+	)
+	require.NoError(t, err)
+
+	// Ensure this meets the eth2client interface requirement.
+	_, isProvider := s.(eth2client.SlotsPerEpochProvider)
+	require.True(t, isProvider)
+
+	// Ensure the value.
+	slotsPerEpoch, err := s.(eth2client.SlotsPerEpochProvider).SlotsPerEpoch(ctx)
+	require.NoError(t, err)
+	// This is hard-coded to the common value; may fail on non-standard chains.
+	require.Equal(t, uint64(32), slotsPerEpoch)
+}

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -30,6 +30,8 @@ var upgradeFunctions = map[uint64][]func(context.Context, *Service) error{
 	1: {
 		validatorsEpochNull,
 		createDeposits,
+		createChainSpec,
+		createGenesis,
 	},
 }
 
@@ -133,6 +135,41 @@ func createDeposits(ctx context.Context, s *Service) error {
 	if _, err := tx.Exec(ctx, "CREATE UNIQUE INDEX i_deposits_1 ON t_deposits(f_inclusion_slot,f_inclusion_block_root,f_inclusion_index)"); err != nil {
 		return errors.Wrap(err, "failed to create deposits index")
 	}
+	return nil
+}
+
+// createChainSpec creates the t_chain_spec table.
+func createChainSpec(ctx context.Context, s *Service) error {
+	tx := s.tx(ctx)
+	if tx == nil {
+		return ErrNoTransaction
+	}
+
+	if _, err := tx.Exec(ctx, `CREATE TABLE t_chain_spec (
+  f_key TEXT NOT NULL PRIMARY KEY
+ ,f_value TEXT NOT NULL
+)`); err != nil {
+		return errors.Wrap(err, "failed to create chain spec table")
+	}
+
+	return nil
+}
+
+// createGenesis creates the t_genesis table.
+func createGenesis(ctx context.Context, s *Service) error {
+	tx := s.tx(ctx)
+	if tx == nil {
+		return ErrNoTransaction
+	}
+
+	if _, err := tx.Exec(ctx, `CREATE TABLE t_genesis (
+  f_validators_root BYTEA NOT NULL PRIMARY KEY
+ ,f_time TIMESTAMPTZ NOT NULL
+ ,f_fork_version BYTEA NOT NULL
+)`); err != nil {
+		return errors.Wrap(err, "failed to create genesis table")
+	}
+
 	return nil
 }
 

--- a/services/chaindb/service.go
+++ b/services/chaindb/service.go
@@ -16,6 +16,7 @@ package chaindb
 import (
 	"context"
 
+	api "github.com/attestantio/go-eth2-client/api/v1"
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
@@ -77,6 +78,33 @@ type BlocksProvider interface {
 type BlocksSetter interface {
 	// SetBlock sets a block.
 	SetBlock(ctx context.Context, block *Block) error
+}
+
+// ChainSpecProvider defines functions to access chain specification.
+type ChainSpecProvider interface {
+	// ChainSpec fetches all chain specification values.
+	ChainSpec(ctx context.Context) (map[string]interface{}, error)
+
+	// ChainSpecValue fetches a chain specification value given its key.
+	ChainSpecValue(ctx context.Context, key string) (interface{}, error)
+}
+
+// ChainSpecSetter defines functions to create and update chain specification.
+type ChainSpecSetter interface {
+	// SetChainSpecValue sets the value of the provided key.
+	SetChainSpecValue(ctx context.Context, key string, value interface{}) error
+}
+
+// GenesisProvider defines functions to access genesis information.
+type GenesisProvider interface {
+	// Genesis fetches genesis values.
+	Genesis(ctx context.Context) (*api.Genesis, error)
+}
+
+// GenesisSetter defines functions to create and update genesis information.
+type GenesisSetter interface {
+	// SetGenesis sets the genesis information.
+	SetGenesis(ctx context.Context, genesis *api.Genesis) error
 }
 
 // ProposerDutiesSetter defines the functions to create and update proposer duties.

--- a/services/spec/standard/parameters.go
+++ b/services/spec/standard/parameters.go
@@ -1,0 +1,81 @@
+// Copyright © 2021 Weald Technology Trading.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"errors"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/rs/zerolog"
+	"github.com/wealdtech/chaind/services/chaindb"
+)
+
+type parameters struct {
+	logLevel   zerolog.Level
+	eth2Client eth2client.Service
+	chainDB    chaindb.Service
+}
+
+// Parameter is the interface for service parameters.
+type Parameter interface {
+	apply(*parameters)
+}
+
+type parameterFunc func(*parameters)
+
+func (f parameterFunc) apply(p *parameters) {
+	f(p)
+}
+
+// WithLogLevel sets the log level for the module.
+func WithLogLevel(logLevel zerolog.Level) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.logLevel = logLevel
+	})
+}
+
+// WithETH2Client sets the Ethereum 2 client for this module.
+func WithETH2Client(eth2Client eth2client.Service) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.eth2Client = eth2Client
+	})
+}
+
+// WithChainDB sets the chain database for this module.
+func WithChainDB(chainDB chaindb.Service) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.chainDB = chainDB
+	})
+}
+
+// parseAndCheckParameters parses and checks parameters to ensure that mandatory parameters are present and correct.
+func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
+	parameters := parameters{
+		logLevel: zerolog.GlobalLevel(),
+	}
+	for _, p := range params {
+		if params != nil {
+			p.apply(&parameters)
+		}
+	}
+
+	if parameters.eth2Client == nil {
+		return nil, errors.New("no Ethereum 2 client specified")
+	}
+	if parameters.chainDB == nil {
+		return nil, errors.New("no chain database specified")
+	}
+
+	return &parameters, nil
+}

--- a/services/spec/standard/service.go
+++ b/services/spec/standard/service.go
@@ -1,0 +1,124 @@
+// Copyright © 2021 Weald Technology Trading.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	zerologger "github.com/rs/zerolog/log"
+	"github.com/wealdtech/chaind/services/chaindb"
+)
+
+// Service is a spec service.
+type Service struct {
+	eth2Client      eth2client.Service
+	chainDB         chaindb.Service
+	chainSpecSetter chaindb.ChainSpecSetter
+	genesisSetter   chaindb.GenesisSetter
+}
+
+// module-wide log.
+var log zerolog.Logger
+
+// New creates a new service.
+func New(ctx context.Context, params ...Parameter) (*Service, error) {
+	parameters, err := parseAndCheckParameters(params...)
+	if err != nil {
+		return nil, errors.Wrap(err, "problem with parameters")
+	}
+
+	// Set logging.
+	log = zerologger.With().Str("service", "spec").Str("impl", "standard").Logger()
+	if parameters.logLevel != log.GetLevel() {
+		log = log.Level(parameters.logLevel)
+	}
+
+	chainSpecSetter, isChainSpecSetter := parameters.chainDB.(chaindb.ChainSpecSetter)
+	if !isChainSpecSetter {
+		return nil, errors.New("chain DB does not support chain spec setting")
+	}
+
+	genesisSetter, isGenesisSetter := parameters.chainDB.(chaindb.GenesisSetter)
+	if !isGenesisSetter {
+		return nil, errors.New("chain DB does not support genesis setting")
+	}
+
+	s := &Service{
+		eth2Client:      parameters.eth2Client,
+		chainDB:         parameters.chainDB,
+		chainSpecSetter: chainSpecSetter,
+		genesisSetter:   genesisSetter,
+	}
+
+	// Update spec in the background
+	go s.updateAfterRestart(ctx)
+
+	return s, nil
+}
+
+func (s *Service) updateAfterRestart(ctx context.Context) {
+	ctx, cancel, err := s.chainDB.BeginTx(ctx)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to begin transaction")
+		return
+	}
+
+	if err := s.updateChainSpec(ctx); err != nil {
+		log.Fatal().Err(err).Msg("Failed to update spec")
+	}
+
+	if err := s.updateGenesis(ctx); err != nil {
+		log.Fatal().Err(err).Msg("Failed to update genesis")
+	}
+
+	if err := s.chainDB.CommitTx(ctx); err != nil {
+		cancel()
+		log.Fatal().Err(err).Msg("Failed to commit transaction")
+	}
+
+}
+
+func (s *Service) updateChainSpec(ctx context.Context) error {
+	// Fetch the chain spec.
+	spec, err := s.eth2Client.(eth2client.SpecProvider).Spec(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to obtain chain spec")
+	}
+
+	// Update the database.
+	for k, v := range spec {
+		if err := s.chainSpecSetter.SetChainSpecValue(ctx, k, v); err != nil {
+			return errors.Wrap(err, "failed to set chain spec value")
+		}
+	}
+	return nil
+}
+
+func (s *Service) updateGenesis(ctx context.Context) error {
+	// Fetch genesis parameters.
+	genesis, err := s.eth2Client.(eth2client.GenesisProvider).Genesis(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to obtain genesis")
+	}
+
+	// Update the database.
+	if err := s.genesisSetter.SetGenesis(ctx, genesis); err != nil {
+		return errors.Wrap(err, "failed to set genesis")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds two parameter tables: `f_chain_spec` and `f_genesis`.  `f_chain_spec` contains the specification for the chain, as per the
Ethereum 2.0 specifications document.  `f_genesis` contains information about the genesis of the chain.