### PR TITLE
Make log levels hierarchical.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Development:
+  - make log level configuration hierarchical; if a log level is not present it will use the next one up the hierarchy
   - add t_chain_spec table, holding the chain specification
   - add t_genesis table, holding the chain genesis information
   - add t_deposits table, holding Ethereum 1 deposits recognized on the beacon chain and provided in the beacon block

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Here, `chaindb.url` is the URL of a local PostgreSQL database with pasword 'secr
 ```
 # log-level is the base log level of the process.
 # 'info' should be a suitable log level, unless detailed information is
-# reqiured in which case 'debug' or 'trace' can be used.
+# required in which case 'debug' or 'trace' can be used.
 log-level: info
 # log-file specifies that log output should go to a file.  If this is not
 # present log output will be to stderr.
@@ -98,7 +98,8 @@ chaindb:
   url: postgres://chain:secret@localhost:5432
 # eth2client contains configuration for the Ethereum 2 client.
 eth2client:
-  # log-level is the log level of the specific module.
+  # log-level is the log level of the specific module.  If not present the base log
+  # level will be used.
   log-level: debug
   # address is the address of the beacon node.
   address: localhost:5051

--- a/clients.go
+++ b/clients.go
@@ -40,7 +40,7 @@ func fetchClient(ctx context.Context, address string) (eth2client.Service, error
 	if client, exists = clients[address]; !exists {
 		var err error
 		client, err = autoclient.New(ctx,
-			autoclient.WithLogLevel(util.LogLevel(viper.GetString("eth2client.log-level"))),
+			autoclient.WithLogLevel(util.LogLevel("eth2client")),
 			autoclient.WithTimeout(viper.GetDuration("eth2client.timeout")),
 			autoclient.WithAddress(address))
 		if err != nil {

--- a/logging.go
+++ b/logging.go
@@ -42,7 +42,7 @@ func initLogging() error {
 	}
 
 	// Set the local logger from the global logger.
-	log = zerologger.Logger.With().Logger().Level(util.LogLevel(viper.GetString("log-level")))
+	log = zerologger.Logger.With().Logger().Level(util.LogLevel(""))
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func initProfiling() error {
 func startServices(ctx context.Context) error {
 	log.Trace().Msg("Starting chain database service")
 	chainDB, err := postgresqlchaindb.New(ctx,
-		postgresqlchaindb.WithLogLevel(util.LogLevel(viper.GetString("chaindb.log-level"))),
+		postgresqlchaindb.WithLogLevel(util.LogLevel("chaindb")),
 		postgresqlchaindb.WithConnectionURL(viper.GetString("chaindb.url")),
 	)
 	if err != nil {
@@ -193,7 +193,7 @@ func startServices(ctx context.Context) error {
 
 	log.Trace().Msg("Starting chain time service")
 	chainTime, err := standardchaintime.New(ctx,
-		standardchaintime.WithLogLevel(util.LogLevel(viper.GetString("chaintime.log-level"))),
+		standardchaintime.WithLogLevel(util.LogLevel("chaintime")),
 		standardchaintime.WithGenesisTimeProvider(eth2Client.(eth2client.GenesisTimeProvider)),
 		standardchaintime.WithSlotDurationProvider(eth2Client.(eth2client.SlotDurationProvider)),
 		standardchaintime.WithSlotsPerEpochProvider(eth2Client.(eth2client.SlotsPerEpochProvider)),
@@ -276,7 +276,7 @@ func startSpec(
 	}
 
 	_, err = standardspec.New(ctx,
-		standardspec.WithLogLevel(util.LogLevel(viper.GetString("spec.log-level"))),
+		standardspec.WithLogLevel(util.LogLevel("spec")),
 		standardspec.WithETH2Client(eth2Client),
 		standardspec.WithChainDB(chainDB),
 	)
@@ -306,7 +306,7 @@ func startBlocks(
 	}
 
 	_, err = standardblocks.New(ctx,
-		standardblocks.WithLogLevel(util.LogLevel(viper.GetString("blocks.log-level"))),
+		standardblocks.WithLogLevel(util.LogLevel("blocks")),
 		standardblocks.WithETH2Client(eth2Client),
 		standardblocks.WithChainTime(chainTime),
 		standardblocks.WithChainDB(chainDB),
@@ -339,7 +339,7 @@ func startValidators(
 	}
 
 	_, err = standardvalidators.New(ctx,
-		standardvalidators.WithLogLevel(util.LogLevel(viper.GetString("validators.log-level"))),
+		standardvalidators.WithLogLevel(util.LogLevel("validators")),
 		standardvalidators.WithETH2Client(eth2Client),
 		standardvalidators.WithChainTime(chainTime),
 		standardvalidators.WithChainDB(chainDB),
@@ -371,7 +371,7 @@ func startBeaconCommittees(
 	}
 
 	_, err = standardbeaconcommittees.New(ctx,
-		standardbeaconcommittees.WithLogLevel(util.LogLevel(viper.GetString("beacon-committees.log-level"))),
+		standardbeaconcommittees.WithLogLevel(util.LogLevel("beacon-committees")),
 		standardbeaconcommittees.WithETH2Client(eth2Client),
 		standardbeaconcommittees.WithChainTime(chainTime),
 		standardbeaconcommittees.WithChainDB(chainDB),
@@ -402,7 +402,7 @@ func startProposerDuties(
 	}
 
 	_, err = standardproposerduties.New(ctx,
-		standardproposerduties.WithLogLevel(util.LogLevel(viper.GetString("proposer-duties.log-level"))),
+		standardproposerduties.WithLogLevel(util.LogLevel("proposer-duties")),
 		standardproposerduties.WithETH2Client(eth2Client),
 		standardproposerduties.WithChainTime(chainTime),
 		standardproposerduties.WithChainDB(chainDB),

--- a/services/beaconcommittees/standard/service.go
+++ b/services/beaconcommittees/standard/service.go
@@ -45,10 +45,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 
 	// Set logging.
-	log = zerologger.With().Str("service", "beaconcommittees").Str("impl", "standard").Logger()
-	if parameters.logLevel != log.GetLevel() {
-		log = log.Level(parameters.logLevel)
-	}
+	log = zerologger.With().Str("service", "beaconcommittees").Str("impl", "standard").Logger().Level(parameters.logLevel)
 
 	beaconCommitteesSetter, isBeaconCommitteesSetter := parameters.chainDB.(chaindb.BeaconCommitteesSetter)
 	if !isBeaconCommitteesSetter {

--- a/services/blocks/standard/service.go
+++ b/services/blocks/standard/service.go
@@ -52,10 +52,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 
 	// Set logging.
-	log = zerologger.With().Str("service", "blocks").Str("impl", "standard").Logger()
-	if parameters.logLevel != log.GetLevel() {
-		log = log.Level(parameters.logLevel)
-	}
+	log = zerologger.With().Str("service", "blocks").Str("impl", "standard").Logger().Level(parameters.logLevel)
 
 	blocksSetter, isBlocksSetter := parameters.chainDB.(chaindb.BlocksSetter)
 	if !isBlocksSetter {

--- a/services/chaindb/postgresql/service.go
+++ b/services/chaindb/postgresql/service.go
@@ -38,10 +38,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 
 	// Set logging.
-	log = zerologger.With().Str("service", "chaindb").Str("impl", "postgresql").Logger()
-	if parameters.logLevel != log.GetLevel() {
-		log = log.Level(parameters.logLevel)
-	}
+	log = zerologger.With().Str("service", "chaindb").Str("impl", "postgresql").Logger().Level(parameters.logLevel)
 
 	pool, err := pgxpool.Connect(context.Background(), parameters.connectionURL)
 	if err != nil {

--- a/services/chaintime/standard/service.go
+++ b/services/chaintime/standard/service.go
@@ -41,10 +41,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 
 	// Set logging.
-	log = zerologger.With().Str("service", "chaintime").Str("impl", "standard").Logger()
-	if parameters.logLevel != log.GetLevel() {
-		log = log.Level(parameters.logLevel)
-	}
+	log = zerologger.With().Str("service", "chaintime").Str("impl", "standard").Logger().Level(parameters.logLevel)
 
 	genesisTime, err := parameters.genesisTimeProvider.GenesisTime(ctx)
 	if err != nil {

--- a/services/proposerduties/standard/service.go
+++ b/services/proposerduties/standard/service.go
@@ -45,10 +45,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 
 	// Set logging.
-	log = zerologger.With().Str("service", "proposerduties").Str("impl", "standard").Logger()
-	if parameters.logLevel != log.GetLevel() {
-		log = log.Level(parameters.logLevel)
-	}
+	log = zerologger.With().Str("service", "proposerduties").Str("impl", "standard").Logger().Level(parameters.logLevel)
 
 	proposerDutiesSetter, isProposerDutiesSetter := parameters.chainDB.(chaindb.ProposerDutiesSetter)
 	if !isProposerDutiesSetter {

--- a/services/validators/standard/service.go
+++ b/services/validators/standard/service.go
@@ -47,10 +47,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 
 	// Set logging.
-	log = zerologger.With().Str("service", "validators").Str("impl", "standard").Logger()
-	if parameters.logLevel != log.GetLevel() {
-		log = log.Level(parameters.logLevel)
-	}
+	log = zerologger.With().Str("service", "validators").Str("impl", "standard").Logger().Level(parameters.logLevel)
 
 	validatorsSetter, isValidatorsSetter := parameters.chainDB.(chaindb.ValidatorsSetter)
 	if !isValidatorsSetter {

--- a/util/logging.go
+++ b/util/logging.go
@@ -14,15 +14,36 @@
 package util
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/rs/zerolog"
 	zerologger "github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
-// LogLevel converts a string to a log level.
+// LogLevel returns the best log level for the path.
+func LogLevel(path string) zerolog.Level {
+	if path == "" {
+		return stringToLevel(viper.GetString("log-level"))
+	}
+
+	key := fmt.Sprintf("%s.log-level", path)
+	if viper.GetString(key) != "" {
+		return stringToLevel(viper.GetString(key))
+	}
+	// Lop off the child and try again.
+	lastPeriod := strings.LastIndex(path, ".")
+	if lastPeriod == -1 {
+		return LogLevel("")
+	} else {
+		return LogLevel(path[0:lastPeriod])
+	}
+}
+
+// stringtoLevel converts a string to a log level.
 // It returns the user-supplied level by default.
-func LogLevel(input string) zerolog.Level {
+func stringToLevel(input string) zerolog.Level {
 	switch strings.ToLower(input) {
 	case "none":
 		return zerolog.Disabled


### PR DESCRIPTION
This change makes configuration of log levels using the `log-level` configuration parameters hierarchical.  For example, given a path in dot notation `a.b`, the following configuration variables will be searched for a value:

  - `a.b.log-level`
  - `a.log-level`
  - `log-level`

The first variable containing a value will be used.

This allows for simple setting of the global level with individual as well as group overrides.