### PR TITLE
Add f_aggregation_indices to t_attestations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Development:
+  - add f_aggregation_indices to t_attestations to provide explicit indices for attestations
   - add t_eth1_deposits table to hold data about deposits on the Ethereum 1 chain (N.B. not currently populated)
   - add f_block_1_root and f_block_2_root to t_proposer_slashings table
   - make log level configuration hierarchical; if a log level is not present it will use the next one up the hierarchy

--- a/schema.sql
+++ b/schema.sql
@@ -89,6 +89,7 @@ CREATE TABLE t_attestations (
  ,f_slot                 BIGINT NOT NULL
  ,f_committee_index      BIGINT NOT NULL
  ,f_aggregation_bits     BYTEA NOT NULL
+ ,f_aggregation_indices  BIGINT[] -- REFERENCES t_validators(f_index)
  ,f_beacon_block_root    BYTEA NOT NULL -- we don't reference this because the block may not exist in the canonical chain
  ,f_source_epoch         BIGINT NOT NULL
  ,f_source_root          BYTEA NOT NULL

--- a/services/chaindb/postgresql/attestations.go
+++ b/services/chaindb/postgresql/attestations.go
@@ -35,18 +35,20 @@ func (s *Service) SetAttestation(ctx context.Context, attestation *chaindb.Attes
                                 ,f_slot
                                 ,f_committee_index
                                 ,f_aggregation_bits
+                                ,f_aggregation_indices
                                 ,f_beacon_block_root
                                 ,f_source_epoch
                                 ,f_source_root
                                 ,f_target_epoch
                                 ,f_target_root
 						  )
-      VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+      VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
       ON CONFLICT (f_inclusion_slot,f_inclusion_block_root,f_inclusion_index) DO
       UPDATE
       SET f_slot = excluded.f_slot
          ,f_committee_index = excluded.f_committee_index
          ,f_aggregation_bits = excluded.f_aggregation_bits
+         ,f_aggregation_indices = excluded.f_aggregation_indices
          ,f_beacon_block_root = excluded.f_beacon_block_root
          ,f_source_epoch = excluded.f_source_epoch
          ,f_source_root = excluded.f_source_root
@@ -59,6 +61,7 @@ func (s *Service) SetAttestation(ctx context.Context, attestation *chaindb.Attes
 		attestation.Slot,
 		attestation.CommitteeIndex,
 		attestation.AggregationBits,
+		attestation.AggregationIndices,
 		attestation.BeaconBlockRoot[:],
 		attestation.SourceEpoch,
 		attestation.SourceRoot[:],
@@ -88,6 +91,7 @@ func (s *Service) AttestationsForBlock(ctx context.Context, blockRoot spec.Root)
             ,f_slot
             ,f_committee_index
             ,f_aggregation_bits
+            ,f_aggregation_indices
             ,f_beacon_block_root
             ,f_source_epoch
             ,f_source_root
@@ -118,6 +122,7 @@ func (s *Service) AttestationsForBlock(ctx context.Context, blockRoot spec.Root)
 			&attestation.Slot,
 			&attestation.CommitteeIndex,
 			&attestation.AggregationBits,
+			&attestation.AggregationIndices,
 			&beaconBlockRoot,
 			&attestation.SourceEpoch,
 			&sourceRoot,
@@ -156,6 +161,7 @@ func (s *Service) AttestationsInBlock(ctx context.Context, blockRoot spec.Root) 
             ,f_slot
             ,f_committee_index
             ,f_aggregation_bits
+            ,f_aggregation_indices
             ,f_beacon_block_root
             ,f_source_epoch
             ,f_source_root
@@ -186,6 +192,7 @@ func (s *Service) AttestationsInBlock(ctx context.Context, blockRoot spec.Root) 
 			&attestation.Slot,
 			&attestation.CommitteeIndex,
 			&attestation.AggregationBits,
+			&attestation.AggregationIndices,
 			&beaconBlockRoot,
 			&attestation.SourceEpoch,
 			&sourceRoot,
@@ -224,6 +231,7 @@ func (s *Service) AttestationsForSlotRange(ctx context.Context, minSlot spec.Slo
             ,f_slot
             ,f_committee_index
             ,f_aggregation_bits
+            ,f_aggregation_indices
             ,f_beacon_block_root
             ,f_source_epoch
             ,f_source_root
@@ -256,6 +264,7 @@ func (s *Service) AttestationsForSlotRange(ctx context.Context, minSlot spec.Slo
 			&attestation.Slot,
 			&attestation.CommitteeIndex,
 			&attestation.AggregationBits,
+			&attestation.AggregationIndices,
 			&beaconBlockRoot,
 			&attestation.SourceEpoch,
 			&sourceRoot,

--- a/services/chaindb/types.go
+++ b/services/chaindb/types.go
@@ -84,6 +84,7 @@ type Attestation struct {
 	Slot               spec.Slot
 	CommitteeIndex     spec.CommitteeIndex
 	AggregationBits    []byte
+	AggregationIndices []spec.ValidatorIndex
 	BeaconBlockRoot    spec.Root
 	SourceEpoch        spec.Epoch
 	SourceRoot         spec.Root

--- a/util/logging.go
+++ b/util/logging.go
@@ -36,9 +36,8 @@ func LogLevel(path string) zerolog.Level {
 	lastPeriod := strings.LastIndex(path, ".")
 	if lastPeriod == -1 {
 		return LogLevel("")
-	} else {
-		return LogLevel(path[0:lastPeriod])
 	}
+	return LogLevel(path[0:lastPeriod])
 }
 
 // stringtoLevel converts a string to a log level.


### PR DESCRIPTION
This change adds a field to attestations, providing the indices of the validators that were part of the attestation.  This is useful, as it
avoids users having to parse a bitlist using beacon committee information.