### PR TITLE
Add aggregate validator balance functions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Development:
+  - add provider functions to fetch aggregate validator balances
   - add f_aggregation_indices to t_attestations to provide explicit indices for attestations
   - add t_eth1_deposits table to hold data about deposits on the Ethereum 1 chain (N.B. not currently populated)
   - add f_block_1_root and f_block_2_root to t_proposer_slashings table

--- a/services/chaindb/postgresql/aggregatevalidatorbalances.go
+++ b/services/chaindb/postgresql/aggregatevalidatorbalances.go
@@ -1,0 +1,221 @@
+// Copyright © 2021 Weald Technology Trading.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+	"github.com/wealdtech/chaind/services/chaindb"
+)
+
+// AggregateValidatorBalancesByIndexAndEpoch fetches the aggregate validator balances for the given validators and epoch.
+func (s *Service) AggregateValidatorBalancesByIndexAndEpoch(
+	ctx context.Context,
+	validatorIndices []spec.ValidatorIndex,
+	epoch spec.Epoch,
+) (
+	*chaindb.AggregateValidatorBalance,
+	error,
+) {
+	if len(validatorIndices) == 0 {
+		return &chaindb.AggregateValidatorBalance{}, nil
+	}
+
+	tx := s.tx(ctx)
+	if tx == nil {
+		ctx, cancel, err := s.BeginTx(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to begin transaction")
+		}
+		tx = s.tx(ctx)
+		defer cancel()
+	}
+
+	var balance spec.Gwei
+	var effectiveBalance spec.Gwei
+
+	err := tx.QueryRow(ctx, fmt.Sprintf(`
+      SELECT SUM(f_balance)
+            ,SUM(f_effective_balance)
+      FROM t_validator_balances
+      JOIN (VALUES %s)
+        AS x(id)
+        ON x.id = t_validator_balances.f_validator_index
+      WHERE f_epoch = $1`, fastIndices(validatorIndices)),
+		uint64(epoch),
+	).Scan(
+		&balance,
+		&effectiveBalance,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	aggregateBalance := &chaindb.AggregateValidatorBalance{
+		Epoch:            epoch,
+		Balance:          balance,
+		EffectiveBalance: effectiveBalance,
+	}
+
+	return aggregateBalance, nil
+}
+
+// AggregateValidatorBalancesByIndexAndEpochRange fetches the aggregate validator balances for the given validators and
+// epoch range.
+// Ranges are inclusive of start and exclusive of end i.e. a request with startEpoch 2 and endEpoch 4 will provide
+// balances for epochs 2 and 3.
+func (s *Service) AggregateValidatorBalancesByIndexAndEpochRange(
+	ctx context.Context,
+	validatorIndices []spec.ValidatorIndex,
+	startEpoch spec.Epoch,
+	endEpoch spec.Epoch,
+) (
+	[]*chaindb.AggregateValidatorBalance,
+	error,
+) {
+	if len(validatorIndices) == 0 {
+		return []*chaindb.AggregateValidatorBalance{}, nil
+	}
+
+	tx := s.tx(ctx)
+	if tx == nil {
+		ctx, cancel, err := s.BeginTx(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to begin transaction")
+		}
+		tx = s.tx(ctx)
+		defer cancel()
+	}
+
+	log.Warn().Uint64("start_epoch", uint64(startEpoch)).Uint64("end_epoch", uint64(endEpoch)).Msg("Entries")
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+      SELECT f_epoch
+            ,SUM(f_balance)
+            ,SUM(f_effective_balance)
+      FROM t_validator_balances
+      JOIN (VALUES %s)
+        AS x(id)
+        ON x.id = t_validator_balances.f_validator_index
+      WHERE f_epoch >= $1
+        AND f_epoch < $2
+      GROUP BY f_epoch
+      ORDER BY f_epoch`, fastIndices(validatorIndices)),
+		uint64(startEpoch),
+		uint64(endEpoch),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	aggregateBalances := make([]*chaindb.AggregateValidatorBalance, 0, int(endEpoch-startEpoch))
+	for rows.Next() {
+		aggregateBalance := &chaindb.AggregateValidatorBalance{}
+		err := rows.Scan(
+			&aggregateBalance.Epoch,
+			&aggregateBalance.Balance,
+			&aggregateBalance.EffectiveBalance,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan row")
+		}
+		aggregateBalances = append(aggregateBalances, aggregateBalance)
+	}
+
+	log.Warn().Int("entries", len(aggregateBalances)).Msg("Entries")
+	return aggregateBalances, nil
+}
+
+// AggregateValidatorBalancesByIndexAndEpochs fetches the validator balances for the given validators at the specified epochs.
+func (s *Service) AggregateValidatorBalancesByIndexAndEpochs(
+	ctx context.Context,
+	validatorIndices []spec.ValidatorIndex,
+	epochs []spec.Epoch,
+) (
+	[]*chaindb.AggregateValidatorBalance,
+	error,
+) {
+	if len(validatorIndices) == 0 {
+		return []*chaindb.AggregateValidatorBalance{}, nil
+	}
+
+	tx := s.tx(ctx)
+	if tx == nil {
+		ctx, cancel, err := s.BeginTx(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to begin transaction")
+		}
+		tx = s.tx(ctx)
+		defer cancel()
+	}
+
+	dbEpochs := make([]uint64, len(epochs))
+	for i, epoch := range epochs {
+		dbEpochs[i] = uint64(epoch)
+	}
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+      SELECT f_epoch
+            ,SUM(f_balance)
+            ,SUM(f_effective_balance)
+      FROM t_validator_balances
+      JOIN (VALUES %s)
+        AS x(id)
+        ON x.id = t_validator_balances.f_validator_index
+      WHERE f_epoch = ANY($1)
+      ORDER BY f_epoch`, fastIndices(validatorIndices)),
+		dbEpochs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	aggregateBalances := make([]*chaindb.AggregateValidatorBalance, 0, len(epochs))
+	for rows.Next() {
+		aggregateBalance := &chaindb.AggregateValidatorBalance{}
+		err := rows.Scan(
+			&aggregateBalance.Epoch,
+			&aggregateBalance.Balance,
+			&aggregateBalance.EffectiveBalance,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to scan row")
+		}
+		aggregateBalances = append(aggregateBalances, aggregateBalance)
+	}
+
+	return aggregateBalances, nil
+}
+
+// fastIndices orders and munges the values for validator indices supplied to balance requests.
+// This allows us to form a query that is significantly faster than the simple IN() style.
+func fastIndices(validatorIndices []spec.ValidatorIndex) string {
+	// Sort the validator indices.
+	sort.Slice(validatorIndices, func(i, j int) bool {
+		return validatorIndices[i] < validatorIndices[j]
+	})
+
+	// Create an array for the validator indices.  This gives us higher performance for our query.
+	indices := make([]string, len(validatorIndices))
+	for i, validatorIndex := range validatorIndices {
+		indices[i] = fmt.Sprintf("(%d)", validatorIndex)
+	}
+
+	return strings.Join(indices, ",")
+}

--- a/services/chaindb/service.go
+++ b/services/chaindb/service.go
@@ -184,6 +184,43 @@ type ValidatorsProvider interface {
 	)
 }
 
+// AggregateValidatorBalancesProvider defines functions to access aggregate validator balances.
+type AggregateValidatorBalancesProvider interface {
+	// AggregateValidatorBalancesByIndexAndEpoch fetches the aggregate validator balances for the given validators and epoch.
+	AggregateValidatorBalancesByIndexAndEpoch(
+		ctx context.Context,
+		indices []spec.ValidatorIndex,
+		epoch spec.Epoch,
+	) (
+		*AggregateValidatorBalance,
+		error,
+	)
+
+	// AggregateValidatorBalancesByIndexAndEpochRange fetches the aggregate validator balances for the given validators and
+	// epoch range.
+	// Ranges are inclusive of start and exclusive of end i.e. a request with startEpoch 2 and endEpoch 4 will provide
+	// balances for epochs 2 and 3.
+	AggregateValidatorBalancesByIndexAndEpochRange(
+		ctx context.Context,
+		indices []spec.ValidatorIndex,
+		startEpoch spec.Epoch,
+		endEpoch spec.Epoch,
+	) (
+		[]*AggregateValidatorBalance,
+		error,
+	)
+
+	// AggregateValidatorBalancesByIndexAndEpochs fetches the validator balances for the given validators at the specified epochs.
+	AggregateValidatorBalancesByIndexAndEpochs(
+		ctx context.Context,
+		indices []spec.ValidatorIndex,
+		epochs []spec.Epoch,
+	) (
+		[]*AggregateValidatorBalance,
+		error,
+	)
+}
+
 // ValidatorsSetter defines functions to create and update validator information.
 type ValidatorsSetter interface {
 	// SetValidator sets a validator.

--- a/services/chaindb/types.go
+++ b/services/chaindb/types.go
@@ -54,6 +54,13 @@ type ValidatorBalance struct {
 	EffectiveBalance spec.Gwei
 }
 
+// AggregateValidatorBalance holds aggreated information about validators' balances at a given epoch.
+type AggregateValidatorBalance struct {
+	Epoch            spec.Epoch
+	Balance          spec.Gwei
+	EffectiveBalance spec.Gwei
+}
+
 // BeaconCommittee holds information for beacon committees.
 type BeaconCommittee struct {
 	Slot      spec.Slot


### PR DESCRIPTION
This adds functions to obtain aggregate validator balances, as an AggregateValidatorBalancesProvider interface.  By mirroring the
unaggregated functions it allows for a significant reduction in the time taken to obtain simple aggregate validator metrics.