### PR TITLE
Add vote finalizer.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Development:
+  - add f_target_correct and f_head_correct to t_attestations; NULL if not yet sure
   - add f_canonical to t_blocks to state if a block is canonical (true), non-canonical (false) or not yet sure (NULL)
   - add provider functions to fetch aggregate validator balances
   - add f_aggregation_indices to t_attestations to provide explicit indices for attestations

--- a/schema.sql
+++ b/schema.sql
@@ -100,6 +100,8 @@ CREATE TABLE t_attestations (
  ,f_source_root          BYTEA NOT NULL
  ,f_target_epoch         BIGINT NOT NULL
  ,f_target_root          BYTEA NOT NULL
+ ,f_target_correct       BOOL
+ ,f_head_correct         BOOL
 );
 CREATE UNIQUE INDEX i_attestations_1 ON t_attestations(f_inclusion_slot,f_inclusion_block_root,f_inclusion_index);
 CREATE INDEX i_attestations_2 ON t_attestations(f_slot);

--- a/services/chaindb/service.go
+++ b/services/chaindb/service.go
@@ -29,7 +29,12 @@ type AttestationsProvider interface {
 	AttestationsInBlock(ctx context.Context, blockRoot spec.Root) ([]*Attestation, error)
 
 	// AttestationsForSlotRange fetches all attestations made for the given slot range.
-	AttestationsForSlotRange(ctx context.Context, minSlot spec.Slot, maxSlot spec.Slot) ([]*Attestation, error)
+	// Ranges are inclusive of start and exclusive of end i.e. a request with startSlot 2 and endSlot 4 will provide
+	// attestations for slots 2 and 3.
+	AttestationsForSlotRange(ctx context.Context, startSlot spec.Slot, endSlot spec.Slot) ([]*Attestation, error)
+
+	// IndeterminateAttestationSlots fetches the slots in the given range with attestations that do not have a canonical status.
+	IndeterminateAttestationSlots(ctx context.Context, minSlot spec.Slot, maxSlot spec.Slot) ([]spec.Slot, error)
 }
 
 // AttestationsSetter defines functions to create and update attestations.

--- a/services/chaindb/types.go
+++ b/services/chaindb/types.go
@@ -98,6 +98,8 @@ type Attestation struct {
 	SourceRoot         spec.Root
 	TargetEpoch        spec.Epoch
 	TargetRoot         spec.Root
+	TargetCorrect      *bool
+	HeadCorrect        *bool
 }
 
 // Deposit holds information about an Ethereum 2 deposit included by a block.

--- a/services/finalizer/standard/handler.go
+++ b/services/finalizer/standard/handler.go
@@ -14,12 +14,14 @@
 package standard
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
 	spec "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/jackc/pgx/v4"
 	"github.com/pkg/errors"
+	"github.com/wealdtech/chaind/services/chaindb"
 )
 
 // OnFinalityCheckpointReceived receives finality checkpoint notifications.
@@ -43,14 +45,21 @@ func (s *Service) OnFinalityCheckpointReceived(
 	}
 	defer s.activitySem.Release(1)
 
-	if err := s.updateCanonicalBlocks(ctx, blockRoot); err != nil {
+	log.Trace().Msg("Updating canonical blocks")
+	if err := s.updateCanonicalBlocks(ctx, blockRoot, true /* incremental */); err != nil {
 		log.Warn().Err(err).Msg("Failed to update canonical blocks")
 	}
+
+	log.Trace().Msg("Updating attestation votes")
+	if err := s.updateAttestations(ctx, epoch); err != nil {
+		log.Warn().Err(err).Msg("Failed to update attestations")
+	}
+
+	log.Trace().Msg("Finished handling finality checkpoint")
 }
 
 // updateCanonicalBlocks updates all canonical blocks given a canonical block root.
-func (s *Service) updateCanonicalBlocks(ctx context.Context, root spec.Root) error {
-
+func (s *Service) updateCanonicalBlocks(ctx context.Context, root spec.Root, incremental bool) error {
 	block, err := s.blocksProvider.BlockByRoot(ctx, root)
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -61,7 +70,7 @@ func (s *Service) updateCanonicalBlocks(ctx context.Context, root spec.Root) err
 		return errors.Wrap(err, "failed to obtain block supplied by finalized checkpoint")
 	}
 
-	if err := s.canonicalizeBlocks(ctx, root); err != nil {
+	if err := s.canonicalizeBlocks(ctx, root, incremental); err != nil {
 		return errors.Wrap(err, "failed to update canonical blocks from canonical root")
 	}
 
@@ -73,7 +82,7 @@ func (s *Service) updateCanonicalBlocks(ctx context.Context, root spec.Root) err
 }
 
 // canonicalizeBlocks marks the given block and all its parents as canonical.
-func (s *Service) canonicalizeBlocks(ctx context.Context, root spec.Root) error {
+func (s *Service) canonicalizeBlocks(ctx context.Context, root spec.Root, incremental bool) error {
 	dbCtx, cancel, err := s.chainDB.BeginTx(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to begin transaction")
@@ -81,21 +90,28 @@ func (s *Service) canonicalizeBlocks(ctx context.Context, root spec.Root) error 
 
 	block, err := s.blocksProvider.BlockByRoot(dbCtx, root)
 	if err != nil {
+		if err == pgx.ErrNoRows {
+			return fmt.Errorf("missing canonical block %#x; please restart chaind with --blocks.start-slot=0 and --finalizer.enable=false to catch up missing blocks, then restart again without to allow finalizer to resume", root)
+		}
+
 		cancel()
-		return errors.Wrap(err, "failed to obtain canonical block")
+		return errors.Wrap(err, fmt.Sprintf("failed to obtain canonical block %#x", root))
 	}
 
-	if block.Canonical != nil && *block.Canonical {
+	if block.Canonical != nil && *block.Canonical && incremental {
 		// Canonical chain fully linked; done.
 		cancel()
 		return nil
 	}
 
-	canonical := true
-	block.Canonical = &canonical
-	if err := s.blocksSetter.SetBlock(dbCtx, block); err != nil {
-		cancel()
-		return errors.Wrap(err, "failed to set block to canonical")
+	// Update if the current status is either indeterminate or non-canonical.
+	if block.Canonical == nil || !*block.Canonical {
+		canonical := true
+		block.Canonical = &canonical
+		if err := s.blocksSetter.SetBlock(dbCtx, block); err != nil {
+			cancel()
+			return errors.Wrap(err, "failed to set block to canonical")
+		}
 	}
 
 	if err := s.chainDB.CommitTx(dbCtx); err != nil {
@@ -109,7 +125,7 @@ func (s *Service) canonicalizeBlocks(ctx context.Context, root spec.Root) error 
 	}
 
 	// Recurse.
-	return s.canonicalizeBlocks(ctx, block.ParentRoot)
+	return s.canonicalizeBlocks(ctx, block.ParentRoot, incremental)
 }
 
 // noncanonicalizeBlocks marks all indeterminate blocks before the given slot as non-canonical.
@@ -142,6 +158,161 @@ func (s *Service) noncanonicalizeBlocks(ctx context.Context, slot spec.Slot) err
 		cancel()
 		return errors.Wrap(err, "failed to commit transaction")
 	}
+
+	return nil
+}
+
+// updateAttestations updates attestations given a finalized epoch.
+func (s *Service) updateAttestations(ctx context.Context, epoch spec.Epoch) error {
+
+	md, err := s.getMetadata(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to obtain metadata")
+	}
+
+	// Obtain all attestations since the last finalized epoch, and update them.
+
+	// First epoch is last finalized epoch + 1, unless it's 0 because we don't know the
+	// difference between actually 0 and undefined.
+	firstEpoch := md.LastFinalizedEpoch
+	if firstEpoch != 0 {
+		firstEpoch++
+	}
+
+	for curEpoch := firstEpoch; curEpoch < epoch; curEpoch++ {
+		ctx, cancel, err := s.chainDB.BeginTx(ctx)
+		if err != nil {
+			cancel()
+			return errors.Wrap(err, "failed to begin transaction")
+		}
+		if err := s.updateAttestationsForEpoch(ctx, curEpoch); err != nil {
+			cancel()
+			return errors.Wrap(err, "failed to update attestations for epoch")
+		}
+		md.LastFinalizedEpoch = curEpoch
+		if err := s.setMetadata(ctx, md); err != nil {
+			cancel()
+			return errors.Wrap(err, "failed to update metadata for epoch")
+		}
+		if err := s.chainDB.CommitTx(ctx); err != nil {
+			cancel()
+			return errors.Wrap(err, "failed to commit transaction")
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) updateAttestationsForEpoch(ctx context.Context, epoch spec.Epoch) error {
+	// epoch is a finalized epoch, so fetch all attestations for the epoch.
+	attestations, err := s.chainDB.(chaindb.AttestationsProvider).AttestationsForSlotRange(ctx, s.chainTime.FirstSlotOfEpoch(epoch), s.chainTime.FirstSlotOfEpoch(epoch+1))
+	if err != nil {
+		return errors.Wrap(err, "failed to obtain attestations for epoch")
+	}
+
+	// Keep track of roots for epochs to reduce lookups.
+	epochRoots := make(map[spec.Epoch]spec.Root)
+
+	// Keep track of roots for heads to reduce lookups.
+	headRoots := make(map[spec.Slot]spec.Root)
+
+	for _, attestation := range attestations {
+		if err := s.updateAttestationTargetCorrect(ctx, attestation, epochRoots); err != nil {
+			return errors.Wrap(err, "failed to update attestation target vote state")
+		}
+		if err := s.updateAttestationHeadCorrect(ctx, attestation, headRoots); err != nil {
+			return errors.Wrap(err, "failed to update attestation head vote state")
+		}
+		if err := s.chainDB.(chaindb.AttestationsSetter).SetAttestation(ctx, attestation); err != nil {
+			return errors.Wrap(err, "failed to update attestation")
+		}
+		log.Trace().Uint64("inclusion_slot", uint64(attestation.InclusionSlot)).Uint64("inclusion_index", attestation.InclusionIndex).Msg("Updated attestation")
+	}
+
+	return nil
+}
+
+// updateAttestationTargetCorrect updates the attestation to confirm if its target vote is correct.
+// An attestation has a correct target vote if it matches the root of the latest canonical block
+// since the start of the target epoch.
+func (s *Service) updateAttestationTargetCorrect(ctx context.Context, attestation *chaindb.Attestation, epochRoots map[spec.Epoch]spec.Root) error {
+	targetCorrect := false
+	if epochRoot, exists := epochRoots[attestation.TargetEpoch]; exists {
+		targetCorrect = bytes.Equal(attestation.TargetRoot[:], epochRoot[:])
+	} else {
+		// Start with first slot of the target epoch.
+		startSlot := s.chainTime.FirstSlotOfEpoch(attestation.TargetEpoch)
+		// Work backwards until we find a canonical block.
+		canonicalBlockFound := false
+		for slot := startSlot; !canonicalBlockFound; slot-- {
+			log.Trace().Uint64("slot", uint64(slot)).Msg("Fetching blocks at slot")
+			blocks, err := s.chainDB.(chaindb.BlocksProvider).BlocksBySlot(ctx, slot)
+			if err != nil {
+				return errors.Wrap(err, "failed to obtain block")
+			}
+			for _, block := range blocks {
+				if block.Canonical != nil && *block.Canonical {
+					log.Trace().Uint64("target_epoch", uint64(attestation.TargetEpoch)).Uint64("slot", uint64(block.Slot)).Msg("Found canonical block")
+					canonicalBlockFound = true
+					epochRoots[attestation.TargetEpoch] = block.Root
+					targetCorrect = bytes.Equal(attestation.TargetRoot[:], block.Root[:])
+					break
+				}
+			}
+			if slot == 0 {
+				break
+			}
+		}
+		if !canonicalBlockFound {
+			return errors.New("failed to obtain canonical block, cannot update attestation")
+		}
+	}
+
+	attestation.TargetCorrect = &targetCorrect
+
+	return nil
+}
+
+// updateAttestationHeadCorrect updates the attestation to confirm if its head vote is correct.
+// An attestation has a correct head vote if it matches the root of the last canonical block
+// prior to the attestation slot.
+func (s *Service) updateAttestationHeadCorrect(ctx context.Context,
+	attestation *chaindb.Attestation,
+	headRoots map[spec.Slot]spec.Root,
+) error {
+	headCorrect := false
+	if headRoot, exists := headRoots[attestation.Slot]; exists {
+		headCorrect = bytes.Equal(attestation.BeaconBlockRoot[:], headRoot[:])
+	} else {
+		log.Trace().Uint64("slot", uint64(attestation.Slot)).Msg("Checking attestation head vote")
+		// Start with slot of the attestation.
+		canonicalBlockFound := false
+		for slot := attestation.Slot; !canonicalBlockFound; slot-- {
+			log.Trace().Uint64("slot", uint64(slot)).Msg("Fetching blocks at slot")
+			blocks, err := s.chainDB.(chaindb.BlocksProvider).BlocksBySlot(ctx, slot)
+			if err != nil {
+				return errors.Wrap(err, "failed to obtain block")
+			}
+			for _, block := range blocks {
+				if block.Canonical != nil && *block.Canonical {
+					log.Trace().Uint64("slot", uint64(block.Slot)).Msg("Found canonical block")
+					canonicalBlockFound = true
+					headRoots[attestation.Slot] = block.Root
+					headCorrect = bytes.Equal(attestation.BeaconBlockRoot[:], block.Root[:])
+					log.Trace().Str("attestation_root", fmt.Sprintf("%#x", attestation.BeaconBlockRoot)).Str("block_root", fmt.Sprintf("%#x", block.Root)).Msg("Found canonical block")
+					break
+				}
+			}
+			if slot == 0 {
+				break
+			}
+		}
+		if !canonicalBlockFound {
+			return errors.New("failed to obtain canonical block, cannot update attestation")
+		}
+	}
+
+	attestation.HeadCorrect = &headCorrect
 
 	return nil
 }

--- a/services/finalizer/standard/handler_internal_test.go
+++ b/services/finalizer/standard/handler_internal_test.go
@@ -1,0 +1,88 @@
+// Copyright © 2021 Weald Technology Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	autoeth2client "github.com/attestantio/go-eth2-client/auto"
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	postgresqlchaindb "github.com/wealdtech/chaind/services/chaindb/postgresql"
+	standardchaintime "github.com/wealdtech/chaind/services/chaintime/standard"
+)
+
+func TestUpdateAttestationHeadCorrect(t *testing.T) {
+	ctx := context.Background()
+
+	chainDB, err := postgresqlchaindb.New(ctx,
+		postgresqlchaindb.WithLogLevel(zerolog.Disabled),
+		postgresqlchaindb.WithConnectionURL(os.Getenv("CHAINDB_DATABASE_URL")),
+	)
+	require.NoError(t, err)
+
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithGenesisTimeProvider(chainDB),
+		standardchaintime.WithSlotDurationProvider(chainDB),
+		standardchaintime.WithSlotsPerEpochProvider(chainDB),
+	)
+	require.NoError(t, err)
+
+	eth2Client, err := autoeth2client.New(ctx,
+		autoeth2client.WithAddress(os.Getenv("ETH2CLIENT_ADDRESS")),
+	)
+	require.NoError(t, err)
+
+	s, err := New(ctx,
+		WithChainDB(chainDB),
+		WithChainTime(chainTime),
+		WithETH2Client(eth2Client),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		slot        spec.Slot
+		validator   spec.ValidatorIndex
+		headCorrect bool
+	}{
+		{
+			name:        "Nil",
+			slot:        329828,
+			validator:   7,
+			headCorrect: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			attestations, err := chainDB.AttestationsForSlotRange(ctx, test.slot, test.slot+1)
+			require.NoError(t, err)
+
+			for _, attestation := range attestations {
+				for _, validatorIndex := range attestation.AggregationIndices {
+					if validatorIndex == test.validator {
+						err = s.updateAttestationHeadCorrect(ctx, attestation, make(map[spec.Slot]spec.Root))
+						require.NoError(t, err)
+						require.NotNil(t, attestation.HeadCorrect)
+						require.Equal(t, test.headCorrect, *attestation.HeadCorrect)
+					}
+				}
+			}
+		})
+	}
+}

--- a/services/finalizer/standard/metadata.go
+++ b/services/finalizer/standard/metadata.go
@@ -1,0 +1,59 @@
+// Copyright © 2021 Weald Technology Trading.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"encoding/json"
+
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+)
+
+// metadata stored about this service.
+type metadata struct {
+	LastFinalizedEpoch spec.Epoch   `json:"latest_epoch"`
+	MissedEpochs       []spec.Epoch `json:"missed_epochs,omitempty"`
+}
+
+// metadataKey is the key for the metadata.
+var metadataKey = "finalizer.standard"
+
+// getMetadata gets metadata for this service.
+func (s *Service) getMetadata(ctx context.Context) (*metadata, error) {
+	md := &metadata{}
+	mdJSON, err := s.chainDB.Metadata(ctx, metadataKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch metadata")
+	}
+	if mdJSON == nil {
+		return md, nil
+	}
+	if err := json.Unmarshal(mdJSON, md); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal metadata")
+	}
+	return md, nil
+}
+
+// setMetadata sets metadata for this service.
+func (s *Service) setMetadata(ctx context.Context, md *metadata) error {
+	mdJSON, err := json.Marshal(md)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal metadata")
+	}
+	if err := s.chainDB.SetMetadata(ctx, metadataKey, mdJSON); err != nil {
+		return errors.Wrap(err, "failed to update metadata")
+	}
+	return nil
+}

--- a/services/finalizer/standard/service_test.go
+++ b/services/finalizer/standard/service_test.go
@@ -1,0 +1,103 @@
+// Copyright © 2021 Weald Technology Trading.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	autoeth2client "github.com/attestantio/go-eth2-client/auto"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	postgresqlchaindb "github.com/wealdtech/chaind/services/chaindb/postgresql"
+	standardchaintime "github.com/wealdtech/chaind/services/chaintime/standard"
+	"github.com/wealdtech/chaind/services/finalizer/standard"
+)
+
+func TestService(t *testing.T) {
+	ctx := context.Background()
+
+	chainDB, err := postgresqlchaindb.New(ctx,
+		postgresqlchaindb.WithLogLevel(zerolog.Disabled),
+		postgresqlchaindb.WithConnectionURL(os.Getenv("CHAINDB_DATABASE_URL")),
+	)
+	require.NoError(t, err)
+
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithGenesisTimeProvider(chainDB),
+		standardchaintime.WithSlotDurationProvider(chainDB),
+		standardchaintime.WithSlotsPerEpochProvider(chainDB),
+	)
+	require.NoError(t, err)
+
+	eth2Client, err := autoeth2client.New(ctx,
+		autoeth2client.WithAddress(os.Getenv("ETH2CLIENT_ADDRESS")),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		params []standard.Parameter
+		err    string
+	}{
+		{
+			name: "ChainDBMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithChainTime(chainTime),
+				standard.WithETH2Client(eth2Client),
+			},
+			err: "problem with parameters: no chain database specified",
+		},
+		{
+			name: "ChainTimeMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithChainDB(chainDB),
+				standard.WithETH2Client(eth2Client),
+			},
+			err: "problem with parameters: no chain time specified",
+		},
+		{
+			name: "ETH2ClientMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithChainDB(chainDB),
+				standard.WithChainTime(chainTime),
+			},
+			err: "problem with parameters: no Ethereum 2 client specified",
+		},
+		{
+			name: "Good",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithChainDB(chainDB),
+				standard.WithChainTime(chainTime),
+				standard.WithETH2Client(eth2Client),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := standard.New(context.Background(), test.params...)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds the fields `f_target_correct` and `f_head_correct` to the `t_attestations` table.  It also adds code to the finalizer that augments attestations with details of the correctness of their target and head votes.  It attempts to do this as finality information is obtained, as well as on start-up.

Because modules in chaind are loosely coupled, it is possible for the finalizer to not have the required information in the chaind database to carry out its operations.  In these situations it will retry incrementally at each new finality checkpoint, as for all indeterminate attestations on start-up.