### PR TITLE
Standardise HTTP requests.

### DIFF
--- a/main.go
+++ b/main.go
@@ -589,7 +589,7 @@ func startETH1Deposits(
 
 	log.Trace().Msg("Starting Ethereum 1 deposits service")
 	_, err := getlogseth1deposits.New(ctx,
-		getlogseth1deposits.WithLogLevel(util.LogLevel(viper.GetString("eth1deposits.log-level"))),
+		getlogseth1deposits.WithLogLevel(util.LogLevel("eth1deposits.log-level")),
 		getlogseth1deposits.WithMonitor(monitor),
 		getlogseth1deposits.WithChainDB(chainDB),
 		getlogseth1deposits.WithConnectionURL(viper.GetString("eth1client.address")),

--- a/services/eth1deposits/getlogs/blocknumber.go
+++ b/services/eth1deposits/getlogs/blocknumber.go
@@ -17,9 +17,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -33,42 +30,30 @@ type blockNumberResponse struct {
 
 // blockNumber fetches the current block number from an Ethereum 1 client.
 func (s *Service) blockNumber(ctx context.Context) (uint64, error) {
-	reference, err := url.Parse("/")
+	reference, err := url.Parse("")
 	if err != nil {
 		return 0, errors.Wrap(err, "invalid endpoint")
 	}
 	url := s.base.ResolveReference(reference).String()
 
-	body := bytes.NewBuffer([]byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1901}`))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	reqBody := bytes.NewBuffer([]byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1901}`))
+	respBodyReader, err := s.post(ctx, url, reqBody)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to setup request context")
+		log.Trace().Str("url", url).Err(err).Msg("Request failed")
+		return 0, errors.Wrap(err, "request failed")
 	}
-	req.Header.Set("Content-type", "application/json")
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to call POST endpoint")
-	}
-
-	statusFamily := resp.StatusCode / 100
-	if statusFamily != 2 {
-		data, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return 0, errors.Wrap(err, "failed to read failed POST response")
-		}
-		return 0, fmt.Errorf("POST failed with status %d: %s", resp.StatusCode, string(data))
+	if respBodyReader == nil {
+		return 0, errors.New("empty response")
 	}
 
 	var response blockNumberResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return 0, errors.Wrap(err, "failed to parse newFilter response")
+	if err := json.NewDecoder(respBodyReader).Decode(&response); err != nil {
+		return 0, errors.Wrap(err, "invalid response")
 	}
 
 	blockNumber, err := strconv.ParseUint(strings.TrimPrefix(response.Result, "0x"), 16, 64)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to parse result")
+		return 0, errors.Wrap(err, "invalid block number")
 	}
 
 	return blockNumber, nil

--- a/services/eth1deposits/getlogs/blocktimestampbyhash.go
+++ b/services/eth1deposits/getlogs/blocktimestampbyhash.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -37,42 +35,30 @@ type blockByHashBlockResponse struct {
 
 // blockTimestampByHash fetches the timestamp of a block given its hash.
 func (s *Service) blockTimestampByHash(ctx context.Context, blockHash []byte) (time.Time, error) {
-	reference, err := url.Parse("/")
+	reference, err := url.Parse("")
 	if err != nil {
 		return time.Time{}, errors.Wrap(err, "invalid endpoint")
 	}
 	url := s.base.ResolveReference(reference).String()
 
-	body := bytes.NewBuffer([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_getBlockByHash","params":["%#x",false],"id":1901}`, blockHash)))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	reqBody := bytes.NewBuffer([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_getBlockByHash","params":["%#x",false],"id":1901}`, blockHash)))
+	respBodyReader, err := s.post(ctx, url, reqBody)
 	if err != nil {
-		return time.Time{}, errors.Wrap(err, "failed to setup request context")
+		log.Trace().Str("url", url).Err(err).Msg("Request failed")
+		return time.Time{}, errors.Wrap(err, "request failed")
 	}
-	req.Header.Set("Content-type", "application/json")
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return time.Time{}, errors.Wrap(err, "failed to call POST endpoint")
-	}
-
-	statusFamily := resp.StatusCode / 100
-	if statusFamily != 2 {
-		data, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return time.Time{}, errors.Wrap(err, "failed to read failed POST response")
-		}
-		return time.Time{}, fmt.Errorf("POST failed with status %d: %s", resp.StatusCode, string(data))
+	if respBodyReader == nil {
+		return time.Time{}, errors.New("empty response")
 	}
 
 	var response blockByHashResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return time.Time{}, errors.Wrap(err, "failed to parse blockByHash response")
+	if err := json.NewDecoder(respBodyReader).Decode(&response); err != nil {
+		return time.Time{}, errors.Wrap(err, "invalid response")
 	}
 
 	timestamp, err := strconv.ParseInt(strings.TrimPrefix(response.Result.Timestamp, "0x"), 16, 64)
 	if err != nil {
-		return time.Time{}, errors.Wrap(err, "failed to parse result")
+		return time.Time{}, errors.Wrap(err, "invalid timestamp")
 	}
 
 	return time.Unix(timestamp, 0), nil

--- a/services/eth1deposits/getlogs/http.go
+++ b/services/eth1deposits/getlogs/http.go
@@ -1,0 +1,85 @@
+// Copyright © 2021 Weald Technology Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getlogs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	// We seed math.rand here so that we can obtain different IDs for requests.
+	// This is purely used as a way to match request and response entries in logs, so there is no
+	// requirement for this to cryptographically secure.
+	rand.Seed(time.Now().UnixNano())
+}
+
+// post sends an HTTP post request and returns the body.
+func (s *Service) post(ctx context.Context, endpoint string, body io.Reader) (io.Reader, error) {
+	// #nosec G404
+	log := log.With().Str("id", fmt.Sprintf("%02x", rand.Int31())).Logger()
+	if e := log.Trace(); e.Enabled() {
+		bodyBytes, err := ioutil.ReadAll(body)
+		if err != nil {
+			return nil, errors.New("failed to read request body")
+		}
+		body = bytes.NewReader(bodyBytes)
+
+		e.Str("endpoint", endpoint).Str("body", string(bodyBytes)).Msg("POST request")
+	}
+
+	reference, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid endpoint")
+	}
+	url := s.base.ResolveReference(reference).String()
+
+	opCtx, cancel := context.WithTimeout(ctx, s.timeout)
+	req, err := http.NewRequestWithContext(opCtx, http.MethodPost, url, body)
+	if err != nil {
+		cancel()
+		return nil, errors.Wrap(err, "failed to create POST request")
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		cancel()
+		return nil, errors.Wrap(err, "failed to call POST endpoint")
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		cancel()
+		return nil, errors.Wrap(err, "failed to read POST response")
+	}
+
+	statusFamily := resp.StatusCode / 100
+	if statusFamily != 2 {
+		cancel()
+		return nil, fmt.Errorf("POST failed with status %d: %s", resp.StatusCode, string(data))
+	}
+	cancel()
+
+	log.Trace().Str("response", string(data)).Msg("POST response")
+
+	return bytes.NewReader(data), nil
+}

--- a/services/eth1deposits/getlogs/service.go
+++ b/services/eth1deposits/getlogs/service.go
@@ -36,6 +36,7 @@ var log zerolog.Logger
 // Service is an Ethereum 1 deposits service that fetches deposits through fetching logs.
 type Service struct {
 	chainDB                chaindb.Service
+	timeout                time.Duration
 	base                   *url.URL
 	client                 *http.Client
 	eth1DepositsSetter     chaindb.ETH1DepositsSetter
@@ -98,6 +99,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 
 	s := &Service{
 		chainDB:                parameters.chainDB,
+		timeout:                30 * time.Second,
 		eth1DepositsSetter:     parameters.eth1DepositsSetter,
 		base:                   base,
 		client:                 client,

--- a/services/eth1deposits/getlogs/transactionbyhash.go
+++ b/services/eth1deposits/getlogs/transactionbyhash.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -31,37 +29,25 @@ type transactionByHashResponse struct {
 
 // transactionByHash fetches a transaction receipt given its hash.
 func (s *Service) transactionByHash(ctx context.Context, txHash []byte) (*transaction, error) {
-	reference, err := url.Parse("/")
+	reference, err := url.Parse("")
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid endpoint")
 	}
 	url := s.base.ResolveReference(reference).String()
 
-	body := bytes.NewBuffer([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["%#x"],"id":1901}`, txHash)))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	reqBody := bytes.NewBuffer([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["%#x"],"id":1901}`, txHash)))
+	respBodyReader, err := s.post(ctx, url, reqBody)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to setup request context")
+		log.Trace().Str("url", url).Err(err).Msg("Request failed")
+		return nil, errors.Wrap(err, "request failed")
 	}
-	req.Header.Set("Content-type", "application/json")
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to call POST endpoint")
-	}
-
-	statusFamily := resp.StatusCode / 100
-	if statusFamily != 2 {
-		data, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to read failed POST response")
-		}
-		return nil, fmt.Errorf("POST failed with status %d: %s", resp.StatusCode, string(data))
+	if respBodyReader == nil {
+		return nil, errors.New("empty response")
 	}
 
 	var response transactionByHashResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return nil, errors.Wrap(err, "failed to parse transactionByHash response")
+	if err := json.NewDecoder(respBodyReader).Decode(&response); err != nil {
+		return nil, errors.Wrap(err, "invalid response")
 	}
 
 	return response.Result, nil


### PR DESCRIPTION
HTTP requests in the eth1deposits module used individual code to make their calls.  This change provides a single call that is standardised across the methods.  It also ensures that connections are closed in a timely fashion, avoiding potential resource exhaustion.