### PR TITLE
Ensure node is in suitable state before starting.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.3.5:
+  - wait until chain has started and node is synced before fetching data
+
 0.3.4:
   - update summarizer metadata for each update
   - avoid crash in situation where transaction receipt is no longer available


### PR DESCRIPTION
Check that the chain has started and that the node is synced before starting to attempt to collect data.