### PR TITLE
Fail fast if data unavailable.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.3.6:
+  - on failure to gather data wait and retry rather than mark as missed
+
 0.3.5:
   - wait until chain has started and node is synced before fetching data
 

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "0.3.5"
+var ReleaseVersion = "0.3.6"
 
 func main() {
 	os.Exit(main2())

--- a/services/beaconcommittees/standard/service.go
+++ b/services/beaconcommittees/standard/service.go
@@ -24,6 +24,7 @@ import (
 	zerologger "github.com/rs/zerolog/log"
 	"github.com/wealdtech/chaind/services/chaindb"
 	"github.com/wealdtech/chaind/services/chaintime"
+	"golang.org/x/sync/semaphore"
 )
 
 // Service is a chain database service.
@@ -32,6 +33,7 @@ type Service struct {
 	chainDB                chaindb.Service
 	beaconCommitteesSetter chaindb.BeaconCommitteesSetter
 	chainTime              chaintime.Service
+	activitySem            *semaphore.Weighted
 }
 
 // module-wide log.
@@ -60,6 +62,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		chainDB:                parameters.chainDB,
 		beaconCommitteesSetter: beaconCommitteesSetter,
 		chainTime:              parameters.chainTime,
+		activitySem:            semaphore.NewWeighted(1),
 	}
 
 	// Update to current epoch before starting (in the background).
@@ -83,7 +86,7 @@ func (s *Service) updateAfterRestart(ctx context.Context, startEpoch int64) {
 	}
 
 	log.Info().Uint64("epoch", uint64(md.LatestEpoch)).Msg("Catching up from epoch")
-	s.catchupOnRestart(ctx, md)
+	s.catchup(ctx, md)
 	if len(md.MissedEpochs) > 0 {
 		// Need this as a []uint64 for logging only.
 		missedEpochs := make([]uint64, len(md.MissedEpochs))
@@ -94,7 +97,7 @@ func (s *Service) updateAfterRestart(ctx context.Context, startEpoch int64) {
 		s.handleMissed(ctx, md)
 		// Catchup again, in case handling the missed epochs took a while.
 		log.Info().Uint64("epoch", uint64(md.LatestEpoch)).Msg("Catching up from epoch")
-		s.catchupOnRestart(ctx, md)
+		s.catchup(ctx, md)
 	}
 	log.Info().Msg("Caught up")
 
@@ -129,7 +132,7 @@ func (s *Service) updateAfterRestart(ctx context.Context, startEpoch int64) {
 	}
 }
 
-func (s *Service) catchupOnRestart(ctx context.Context, md *metadata) {
+func (s *Service) catchup(ctx context.Context, md *metadata) {
 	for epoch := md.LatestEpoch; epoch <= s.chainTime.CurrentEpoch(); epoch++ {
 		log := log.With().Uint64("epoch", uint64(epoch)).Logger()
 		// Each update goes in to its own transaction, to make the data available sooner.

--- a/services/proposerduties/standard/handler.go
+++ b/services/proposerduties/standard/handler.go
@@ -35,37 +35,24 @@ func (s *Service) OnBeaconChainHeadUpdated(
 		return
 	}
 
+	// Only allow 1 handler to be active.
+	acquired := s.activitySem.TryAcquire(1)
+	if !acquired {
+		log.Debug().Msg("Another handler running")
+		return
+	}
+
 	epoch := s.chainTime.SlotToEpoch(slot)
 	log := log.With().Uint64("epoch", uint64(epoch)).Logger()
 
-	ctx, cancel, err := s.chainDB.BeginTx(ctx)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to begin transaction on beacon chain head update")
-		return
-	}
-
 	md, err := s.getMetadata(ctx)
 	if err != nil {
+		s.activitySem.Release(1)
 		log.Fatal().Err(err).Msg("Failed to obtain metadata")
 	}
 
-	if err := s.updateProposerDutiesForEpoch(ctx, epoch); err != nil {
-		log.Error().Err(err).Msg("Failed to update proposer duties on beacon chain head update")
-		md.MissedEpochs = append(md.MissedEpochs, epoch)
-	}
-
-	md.LatestEpoch = epoch
-	if err := s.setMetadata(ctx, md); err != nil {
-		log.Error().Err(err).Msg("Failed to set metadata")
-	}
-
-	if err := s.chainDB.CommitTx(ctx); err != nil {
-		log.Error().Err(err).Msg("Failed to commit transaction")
-		cancel()
-		return
-	}
-
-	log.Trace().Msg("Stored proposer duties")
+	s.catchup(ctx, md)
+	s.activitySem.Release(1)
 }
 
 func (s *Service) updateProposerDutiesForEpoch(ctx context.Context, epoch spec.Epoch) error {

--- a/services/summarizer/standard/block.go
+++ b/services/summarizer/standard/block.go
@@ -150,6 +150,7 @@ func (s *Service) attestationStatsForBlock(ctx context.Context,
 		}
 		seenAttestations[specAttestationRoot] = true
 		if attestation.Canonical == nil || !*attestation.Canonical {
+			log.Debug().Uint64("slot", uint64(attestation.Slot)).Uint64("inclusion_slot", uint64(attestation.InclusionSlot)).Uint64("inclusion_index", attestation.InclusionIndex).Msg("Attestation is not canonical")
 			continue
 		}
 		summary.AttestationsForBlock++

--- a/services/summarizer/standard/handler.go
+++ b/services/summarizer/standard/handler.go
@@ -103,7 +103,7 @@ func (s *Service) onFinalityUpdatedBlocks(ctx context.Context,
 		lastBlockEpoch++
 	}
 
-	// The last epoch updated in the meadata tells us how far we can summarize,
+	// The last epoch updated in the metadata tells us how far we can summarize,
 	// as it checks for the component data.  As such, if the finalized epoch
 	// is beyond our summarized epoch we truncate to the summarized value.
 	// However, if we don't have validator balances the summarizer won't run at all


### PR DESCRIPTION
This patch changes the behaviour of chaind in the face of a failure to obtain data from "mark as missed and carry on" to "stop this attempt at data collection".  With the subsequent introduction of the finalizer and summarizer the former behaviour can result in incorrect summaries, whereas the latter can result in delayed summaries.  The latter is preferable.