### PR TITLE
Provide individual parameters for connection.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.4.1:
+  - provide a more nuanced method for connecting to the chain database other than simple URL
+
 0.4.0:
   - Altair support
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wealdtech/chaind
 go 1.16
 
 require (
-	github.com/attestantio/go-eth2-client v0.7.0
+	github.com/attestantio/go-eth2-client v0.7.1
 	github.com/jackc/pgtype v1.6.2
 	github.com/jackc/pgx/v4 v4.10.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQY
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/attestantio/go-eth2-client v0.7.0 h1:3N4TfKIqS2DS5jCBMqbAzUeL+9LB9Te0froT4NtIDoE=
-github.com/attestantio/go-eth2-client v0.7.0/go.mod h1:kEK9iAAOBoADO5wEkd84FEOzjT1zXgVWveQsqn+uBGg=
+github.com/attestantio/go-eth2-client v0.7.1 h1:BfgvDMfXImrEstf17XPz+FS1A+LeehBEk+hUC7lbGLw=
+github.com/attestantio/go-eth2-client v0.7.1/go.mod h1:kEK9iAAOBoADO5wEkd84FEOzjT1zXgVWveQsqn+uBGg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/services/chaindb/postgresql/forkschedule.go
+++ b/services/chaindb/postgresql/forkschedule.go
@@ -35,7 +35,22 @@ func (s *Service) SetForkSchedule(ctx context.Context, schedule []*phase0.Fork) 
 		return err
 	}
 
-	for _, fork := range schedule {
+	for i, fork := range schedule {
+		if i == 0 && fork.Epoch != 0 {
+			// Create a synthetic genesis fork.
+			_, err := tx.Exec(ctx, `
+      INSERT INTO t_fork_schedule(f_epoch
+                                 ,f_version
+						         )
+      VALUES($1,$2)
+	  `,
+				0,
+				fork.PreviousVersion[:],
+			)
+			if err != nil {
+				return err
+			}
+		}
 		_, err := tx.Exec(ctx, `
       INSERT INTO t_fork_schedule(f_epoch
                                  ,f_version

--- a/services/chaindb/postgresql/parameters.go
+++ b/services/chaindb/postgresql/parameters.go
@@ -22,6 +22,13 @@ import (
 type parameters struct {
 	logLevel      zerolog.Level
 	connectionURL string
+	server        string
+	port          int32
+	user          string
+	password      string
+	clientCert    []byte
+	clientKey     []byte
+	caCert        []byte
 }
 
 // Parameter is the interface for service parameters.
@@ -43,9 +50,59 @@ func WithLogLevel(logLevel zerolog.Level) Parameter {
 }
 
 // WithConnectionURL sets the connection URL for this module.
+// Deprecated.  Use the individual Server/User/Port/... functions.
 func WithConnectionURL(connectionURL string) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.connectionURL = connectionURL
+	})
+}
+
+// WithServer sets the server for this module.
+func WithServer(server string) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.server = server
+	})
+}
+
+// WithUser sets the user for this module.
+func WithUser(user string) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.user = user
+	})
+}
+
+// WithPassword sets the password for this module.
+func WithPassword(password string) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.password = password
+	})
+}
+
+// WithPort sets the port for this module.
+func WithPort(port int32) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.port = port
+	})
+}
+
+// WithClientCert sets the bytes of the client TLS certificate.
+func WithClientCert(cert []byte) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.clientCert = cert
+	})
+}
+
+// WithClientKey sets the bytes of the client TLS key.
+func WithClientKey(key []byte) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.clientKey = key
+	})
+}
+
+// WithCACert sets the bytes of the certificate authority TLS certificate.
+func WithCACert(cert []byte) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.caCert = cert
 	})
 }
 
@@ -60,8 +117,19 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 		}
 	}
 
-	if parameters.connectionURL == "" {
-		return nil, errors.New("no connection URL specified")
+	if parameters.connectionURL != "" {
+		// Allow deprecated connection URL.
+		return &parameters, nil
+	}
+
+	if parameters.server == "" {
+		return nil, errors.New("no server specified")
+	}
+	if parameters.user == "" {
+		return nil, errors.New("no user specified")
+	}
+	if parameters.port == 0 {
+		return nil, errors.New("no port specified")
 	}
 
 	return &parameters, nil


### PR DESCRIPTION
This deprecates the simple URL method and instead uses individual paramters for values such as server, port, username and password.  It also allows configuration of TLS connections, using certificates to provide mutual authentication.