### PR TITLE
Use bulk insert where appropriate.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Development:
+  - use bulk insert for validator balances and validator epoch summaries
+
 0.4.2:
   - add index to t_deposits for validator public key
 

--- a/services/chaindb/postgresql/service_test.go
+++ b/services/chaindb/postgresql/service_test.go
@@ -31,8 +31,8 @@ func TestService(t *testing.T) {
 		err           string
 	}{
 		{
-			name: "ConnectionURLMissing",
-			err:  "problem with parameters: no connection URL specified",
+			name: "ServerMissing",
+			err:  "problem with parameters: no server specified",
 		},
 		{
 			name:          "Good",

--- a/services/chaindb/postgresql/validatorepochsummaries.go
+++ b/services/chaindb/postgresql/validatorepochsummaries.go
@@ -17,8 +17,49 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/jackc/pgx/v4"
 	"github.com/wealdtech/chaind/services/chaindb"
 )
+
+// SetValidatorEpochSummaries sets multiple validator epoch summaries.
+func (s *Service) SetValidatorEpochSummaries(ctx context.Context, summaries []*chaindb.ValidatorEpochSummary) error {
+	tx := s.tx(ctx)
+	if tx == nil {
+		return ErrNoTransaction
+	}
+	_, err := tx.CopyFrom(ctx,
+		pgx.Identifier{"t_validator_epoch_summaries"},
+		[]string{
+			"f_validator_index",
+			"f_epoch",
+			"f_proposer_duties",
+			"f_proposals_included",
+			"f_attestation_included",
+			"f_attestation_target_correct",
+			"f_attestation_head_correct",
+			"f_attestation_inclusion_delay",
+			"f_attestation_source_timely",
+			"f_attestation_target_timely",
+			"f_attestation_head_timely",
+		},
+		pgx.CopyFromSlice(len(summaries), func(i int) ([]interface{}, error) {
+			return []interface{}{
+				summaries[i].Index,
+				summaries[i].Epoch,
+				summaries[i].ProposerDuties,
+				summaries[i].ProposalsIncluded,
+				summaries[i].AttestationIncluded,
+				summaries[i].AttestationTargetCorrect,
+				summaries[i].AttestationHeadCorrect,
+				summaries[i].AttestationInclusionDelay,
+				summaries[i].AttestationSourceTimely,
+				summaries[i].AttestationTargetTimely,
+				summaries[i].AttestationHeadTimely,
+			}, nil
+		}))
+
+	return err
+}
 
 // SetValidatorEpochSummary sets a validator epoch summary.
 func (s *Service) SetValidatorEpochSummary(ctx context.Context, summary *chaindb.ValidatorEpochSummary) error {

--- a/services/chaindb/postgresql/validators.go
+++ b/services/chaindb/postgresql/validators.go
@@ -117,6 +117,32 @@ func (s *Service) SetValidatorBalance(ctx context.Context, balance *chaindb.Vali
 	return err
 }
 
+// SetValidatorBalances sets multiple validator balances.
+func (s *Service) SetValidatorBalances(ctx context.Context, balances []*chaindb.ValidatorBalance) error {
+	tx := s.tx(ctx)
+	if tx == nil {
+		return ErrNoTransaction
+	}
+
+	_, err := tx.CopyFrom(ctx,
+		pgx.Identifier{"t_validator_balances"},
+		[]string{
+			"f_validator_index",
+			"f_epoch",
+			"f_balance",
+			"f_effective_balance",
+		},
+		pgx.CopyFromSlice(len(balances), func(i int) ([]interface{}, error) {
+			return []interface{}{
+				balances[i].Index,
+				balances[i].Epoch,
+				balances[i].Balance,
+				balances[i].EffectiveBalance,
+			}, nil
+		}))
+	return err
+}
+
 // Validators fetches all validators.
 func (s *Service) Validators(ctx context.Context) ([]*chaindb.Validator, error) {
 	tx := s.tx(ctx)

--- a/services/chaindb/service.go
+++ b/services/chaindb/service.go
@@ -306,6 +306,9 @@ type ValidatorsSetter interface {
 
 	// SetValidatorBalance sets a validator balance.
 	SetValidatorBalance(ctx context.Context, validatorBalance *ValidatorBalance) error
+
+	// SetValidatorBalances sets multiple validator balances.
+	SetValidatorBalances(ctx context.Context, validatorBalances []*ValidatorBalance) error
 }
 
 // DepositsProvider defines functions to access deposits.
@@ -334,6 +337,9 @@ type VoluntaryExitsSetter interface {
 type ValidatorEpochSummariesSetter interface {
 	// SetValidatorEpochSummary sets a validator epoch summary.
 	SetValidatorEpochSummary(ctx context.Context, summary *ValidatorEpochSummary) error
+
+	// SetValidatorEpochSummaries sets multiple validator epoch summaries.
+	SetValidatorEpochSummaries(ctx context.Context, summaries []*ValidatorEpochSummary) error
 }
 
 // BlockSummariesSetter defines functions to create and update block summaries.

--- a/services/validators/standard/handler.go
+++ b/services/validators/standard/handler.go
@@ -24,6 +24,7 @@ import (
 )
 
 // OnBeaconChainHeadUpdated receives beacon chain head updated notifications.
+// skipcq: RVV-A0005
 func (s *Service) OnBeaconChainHeadUpdated(
 	ctx context.Context,
 	slot phase0.Slot,
@@ -34,7 +35,7 @@ func (s *Service) OnBeaconChainHeadUpdated(
 	epoch := s.chainTime.SlotToEpoch(slot)
 	log := log.With().Uint64("epoch", uint64(epoch)).Logger()
 
-	if !epochTransition { // skipcq: RVV-A0005
+	if !epochTransition {
 		// Only interested in epoch transitions.
 		return
 	}

--- a/services/validators/standard/handler.go
+++ b/services/validators/standard/handler.go
@@ -27,14 +27,14 @@ import (
 func (s *Service) OnBeaconChainHeadUpdated(
 	ctx context.Context,
 	slot phase0.Slot,
-	blockRoot phase0.Root,
-	stateRoot phase0.Root,
+	_ phase0.Root,
+	_ phase0.Root,
 	epochTransition bool,
 ) {
 	epoch := s.chainTime.SlotToEpoch(slot)
 	log := log.With().Uint64("epoch", uint64(epoch)).Logger()
 
-	if !epochTransition {
+	if !epochTransition { // skipcq: RVV-A0005
 		// Only interested in epoch transitions.
 		return
 	}

--- a/services/validators/standard/handler.go
+++ b/services/validators/standard/handler.go
@@ -119,6 +119,7 @@ func (s *Service) onEpochTransitionValidatorBalances(ctx context.Context,
 	}
 
 	for epoch := md.LatestBalancesEpoch; epoch <= transitionedEpoch; epoch++ {
+		log := log.With().Uint64("epoch", uint64(epoch)).Logger()
 		stateID := fmt.Sprintf("%d", s.chainTime.FirstSlotOfEpoch(epoch))
 		log.Trace().Uint64("slot", uint64(s.chainTime.FirstSlotOfEpoch(epoch))).Msg("Fetching validators")
 		validators, err := s.eth2Client.(eth2client.ValidatorsProvider).Validators(ctx, stateID, nil)
@@ -126,32 +127,43 @@ func (s *Service) onEpochTransitionValidatorBalances(ctx context.Context,
 			return errors.Wrap(err, "failed to obtain validators for validator balances")
 		}
 
-		ctx, cancel, err := s.chainDB.BeginTx(ctx)
+		dbCtx, cancel, err := s.chainDB.BeginTx(ctx)
 		if err != nil {
 			return errors.Wrap(err, "failed to begin transaction for validator balances")
 		}
-		for index, validator := range validators {
-			if s.balances {
-				dbValidatorBalance := &chaindb.ValidatorBalance{
+		if s.balances {
+			dbValidatorBalances := make([]*chaindb.ValidatorBalance, 0, len(validators))
+			for index, validator := range validators {
+				dbValidatorBalances = append(dbValidatorBalances, &chaindb.ValidatorBalance{
 					Index:            index,
 					Epoch:            epoch,
 					Balance:          validator.Balance,
 					EffectiveBalance: validator.Validator.EffectiveBalance,
+				})
+			}
+			if err := s.validatorsSetter.SetValidatorBalances(dbCtx, dbValidatorBalances); err != nil {
+				log.Trace().Err(err).Msg("Bulk insert failed; falling back to individual insert")
+				// This error will have caused the transaction to fail, so cancel it and start a new one.
+				cancel()
+				dbCtx, cancel, err = s.chainDB.BeginTx(ctx)
+				if err != nil {
+					return errors.Wrap(err, "failed to begin transaction for validator balances (2)")
 				}
-				if err := s.validatorsSetter.SetValidatorBalance(ctx, dbValidatorBalance); err != nil {
-					cancel()
-					return errors.Wrap(err, "failed to set validator balance")
+				for _, dbValidatorBalance := range dbValidatorBalances {
+					if err := s.validatorsSetter.SetValidatorBalance(dbCtx, dbValidatorBalance); err != nil {
+						return errors.Wrap(err, "failed to set validator balance")
+					}
 				}
 			}
+			md.LatestBalancesEpoch = epoch
 		}
-		md.LatestBalancesEpoch = epoch
 
-		if err := s.setMetadata(ctx, md); err != nil {
+		if err := s.setMetadata(dbCtx, md); err != nil {
 			cancel()
 			return errors.Wrap(err, "failed to set metadata for validator balances")
 		}
 
-		if err := s.chainDB.CommitTx(ctx); err != nil {
+		if err := s.chainDB.CommitTx(dbCtx); err != nil {
 			cancel()
 			return errors.Wrap(err, "failed to set commit transaction for validator balances")
 		}


### PR DESCRIPTION
Use bulk insert for validator balances and validator epoch summaries, which significantly increases insertion speed.