### PR TITLE
Add f_parent_distance to t_block_summaries.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Development:
+  - add f_parent_distance to t_block_summaries
   - use bulk insert for validator balances and validator epoch summaries
 
 0.4.2:

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "0.4.2"
+var ReleaseVersion = "0.5.0-pre"
 
 func main() {
 	os.Exit(main2())

--- a/services/chaindb/postgresql/blocksummaries.go
+++ b/services/chaindb/postgresql/blocksummaries.go
@@ -30,18 +30,21 @@ func (s *Service) SetBlockSummary(ctx context.Context, summary *chaindb.BlockSum
       INSERT INTO t_block_summaries(f_slot
                                    ,f_attestations_for_block
                                    ,f_duplicate_attestations_for_block
-                                   ,f_votes_for_block)
-      VALUES($1,$2,$3,$4)
+                                   ,f_votes_for_block
+                                   ,f_parent_distance)
+      VALUES($1,$2,$3,$4,$5)
       ON CONFLICT (f_slot) DO
       UPDATE
       SET f_attestations_for_block = excluded.f_attestations_for_block
          ,f_duplicate_attestations_for_block = excluded.f_duplicate_attestations_for_block
          ,f_votes_for_block = excluded.f_votes_for_block
+         ,f_parent_distance = excluded.f_parent_distance
 		 `,
 		summary.Slot,
 		summary.AttestationsForBlock,
 		summary.DuplicateAttestationsForBlock,
 		summary.VotesForBlock,
+		summary.ParentDistance,
 	)
 
 	return err

--- a/services/chaindb/types.go
+++ b/services/chaindb/types.go
@@ -215,6 +215,7 @@ type BlockSummary struct {
 	AttestationsForBlock          int
 	DuplicateAttestationsForBlock int
 	VotesForBlock                 int
+	ParentDistance                int
 }
 
 // EpochSummary provides a summary of an epoch.


### PR DESCRIPTION
f_parent_distance tracks the number slots from a block to its parent, providing additional information around reorg distances.