### PR TITLE
Fix crash when block metadata unavailable.

### DIFF
--- a/services/blocks/standard/handler.go
+++ b/services/blocks/standard/handler.go
@@ -56,7 +56,6 @@ func (s *Service) OnBeaconChainHeadUpdated(
 	md, err := s.getMetadata(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to obtain metadata")
-		md.MissedSlots = append(md.MissedSlots, slot)
 		return
 	}
 


### PR DESCRIPTION
If block metadata is unavailable an attempt is made to mark the block as missed, but missed handling was removed so it causes a crash.  This removes the marking of the block as missed, allowing the code to continue.

Fixes #28 