### PR TITLE
Fix missed sync committee information.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+dev
+  - fix missed sync committee information if first block of period is missed
+
 0.5.0
   - add f_parent_distance to t_block_summaries
   - fix crash on database disconnect

--- a/services/chaintime/service.go
+++ b/services/chaintime/service.go
@@ -37,6 +37,8 @@ type Service interface {
 	SlotToEpoch(slot phase0.Slot) phase0.Epoch
 	// SlotToSyncCommitteePeriod provides the sync committee period of the given slot.
 	SlotToSyncCommitteePeriod(slot phase0.Slot) uint64
+	// EpochToSyncCommitteePeriod provides the sync committee period of the given epoch.
+	EpochToSyncCommitteePeriod(epoch phase0.Epoch) uint64
 	// FirstSlotOfEpoch provides the first slot of the given epoch.
 	FirstSlotOfEpoch(epoch phase0.Epoch) phase0.Slot
 	// TimestampToSlot provides the slot of the given timestamp.

--- a/services/chaintime/standard/service.go
+++ b/services/chaintime/standard/service.go
@@ -146,6 +146,11 @@ func (s *Service) SlotToSyncCommitteePeriod(slot phase0.Slot) uint64 {
 	return uint64(s.SlotToEpoch(slot)) / s.epochsPerSyncCommitteePeriod
 }
 
+// EpochToSyncCommitteePeriod provides the sync committee period of the given epoch.
+func (s *Service) EpochToSyncCommitteePeriod(epoch phase0.Epoch) uint64 {
+	return uint64(epoch) / s.epochsPerSyncCommitteePeriod
+}
+
 // FirstSlotOfEpoch provides the first slot of the given epoch.
 func (s *Service) FirstSlotOfEpoch(epoch phase0.Epoch) phase0.Slot {
 	return phase0.Slot(uint64(epoch) * s.slotsPerEpoch)

--- a/services/synccommittees/standard/handler.go
+++ b/services/synccommittees/standard/handler.go
@@ -26,9 +26,6 @@ import (
 func (s *Service) OnBeaconChainHeadUpdated(
 	ctx context.Context,
 	slot phase0.Slot,
-	blockRoot phase0.Root,
-	stateRoot phase0.Root,
-	epochTransition bool,
 ) {
 	// Only allow 1 handler to be active.
 	acquired := s.activitySem.TryAcquire(1)

--- a/services/synccommittees/standard/service.go
+++ b/services/synccommittees/standard/service.go
@@ -117,7 +117,7 @@ func (s *Service) updateAfterRestart(ctx context.Context, startPeriod int64) {
 	// Set up the handler for new chain head updates.
 	if err := s.eventsProvider.Events(ctx, []string{"head"}, func(event *api.Event) {
 		eventData := event.Data.(*api.HeadEvent)
-		s.OnBeaconChainHeadUpdated(ctx, eventData.Slot, eventData.Block, eventData.State, eventData.EpochTransition)
+		s.OnBeaconChainHeadUpdated(ctx, eventData.Slot)
 	}); err != nil {
 		log.Fatal().Err(err).Msg("Failed to add sync chain head updated handler")
 	}


### PR DESCRIPTION
If the first block of sync committee period is missed then the sync committee data is not obtained.  This checks on each slot to see if the sync committee period is ahead of our latest fetched period to ensure that they are fetched at the first opportunity.