### PR TITLE
Fix certificates in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,19 @@ RUN go mod download
 
 COPY . .
 
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache \
+    ca-certificates \
+    && update-ca-certificates 2>/dev/null || true
+
 RUN go build
 
 FROM debian:buster-slim
 
 WORKDIR /app
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/chaind /app
 
 ENTRYPOINT ["/app/chaind"]


### PR DESCRIPTION
**Fixed issue**:

When running `chaind` from docker, the following error appears when trying to scan for eth1 deposits (`eth1deposits.enable=true` and `eth1client.address=...`):

`x509: certificate signed by unknown authority`

```
{"level":"error","error":"failed to start Ethereum 1 deposits service: failed to start Ethereum 1 deposits service: failed to obtain Ethereum 1 deposits service: failed to obtain Ethereum 1 chain ID: failed to request chain ID: failed to call POST endpoint: Post \"https://eth-mainnet.alchemyapi.io/v2/xxx\": x509: certificate signed by unknown authority
```

**How to reproduce it?**
* Build `chaind` with docker
* Start the docker image with `eth1deposits.enable=true` and a valid eth1 endpoint `eth1client.address=...`

**Description of the fix:**

This is a [common issue](https://stackoverflow.com/questions/64462922/docker-multi-stage-build-go-image-x509-certificate-signed-by-unknown-authorit) that can be fixed by copying the certificates in the build process.