### PR TITLE
Avoid uninitialised metrics.

### DIFF
--- a/services/blocks/standard/metrics.go
+++ b/services/blocks/standard/metrics.go
@@ -71,7 +71,9 @@ func registerPrometheusMetrics(ctx context.Context) error {
 // called directly, as it is called as part ofr monitorBlockProcessed.
 func monitorLatestBlock(slot phase0.Slot) {
 	highestSlot = slot
-	latestBlock.Set(float64(slot))
+	if latestBlock != nil {
+		latestBlock.Set(float64(slot))
+	}
 }
 
 func monitorBlockProcessed(slot phase0.Slot) {

--- a/services/finalizer/standard/metrics.go
+++ b/services/finalizer/standard/metrics.go
@@ -70,7 +70,9 @@ func registerPrometheusMetrics(ctx context.Context) error {
 // called directly, as it is called as part ofr monitorEpochProcessed.
 func monitorLatestEpoch(epoch phase0.Epoch) {
 	highestEpoch = epoch
-	latestEpoch.Set(float64(epoch))
+	if latestEpoch != nil {
+		latestEpoch.Set(float64(epoch))
+	}
 }
 
 func monitorEpochProcessed(epoch phase0.Epoch) {

--- a/services/summarizer/standard/metrics.go
+++ b/services/summarizer/standard/metrics.go
@@ -70,7 +70,9 @@ func registerPrometheusMetrics(ctx context.Context) error {
 // called directly, as it is called as part ofr monitorEpochProcessed.
 func monitorLatestEpoch(epoch phase0.Epoch) {
 	highestEpoch = epoch
-	latestEpoch.Set(float64(epoch))
+	if latestEpoch != nil {
+		latestEpoch.Set(float64(epoch))
+	}
 }
 
 func monitorEpochProcessed(epoch phase0.Epoch) {


### PR DESCRIPTION
Always check for initialisation of prometheus metrics prior to use.

Fixes #45 