### PR TITLE
Speed up epoch summaries

### DIFF
--- a/services/chaindb/postgresql/validators.go
+++ b/services/chaindb/postgresql/validators.go
@@ -279,7 +279,7 @@ func (s *Service) ValidatorsByIndex(ctx context.Context, indices []phase0.Valida
 	return validators, nil
 }
 
-// ValidatorBalancesByEpoch fetches the validator balances for the given validators and epoch.
+// ValidatorBalancesByEpoch fetches the validator balances for the given epoch.
 func (s *Service) ValidatorBalancesByEpoch(
 	ctx context.Context,
 	epoch phase0.Epoch,

--- a/services/chaindb/service.go
+++ b/services/chaindb/service.go
@@ -231,13 +231,12 @@ type ValidatorsProvider interface {
 	// ValidatorsByIndex fetches all validators matching the given indices.
 	ValidatorsByIndex(ctx context.Context, indices []phase0.ValidatorIndex) (map[phase0.ValidatorIndex]*Validator, error)
 
-	// ValidatorBalancesByIndexAndEpoch fetches the validator balances for the given validators and epoch.
-	ValidatorBalancesByIndexAndEpoch(
+	// ValidatorBalancesByEpoch fetches all validator balances for the given epoch.
+	ValidatorBalancesByEpoch(
 		ctx context.Context,
-		indices []phase0.ValidatorIndex,
 		epoch phase0.Epoch,
 	) (
-		map[phase0.ValidatorIndex]*ValidatorBalance,
+		[]*ValidatorBalance,
 		error,
 	)
 

--- a/services/chaindb/service.go
+++ b/services/chaindb/service.go
@@ -240,6 +240,16 @@ type ValidatorsProvider interface {
 		error,
 	)
 
+	// ValidatorBalancesByIndexAndEpoch fetches the validator balances for the given validators and epoch.
+	ValidatorBalancesByIndexAndEpoch(
+		ctx context.Context,
+		indices []phase0.ValidatorIndex,
+		epoch phase0.Epoch,
+	) (
+		map[phase0.ValidatorIndex]*ValidatorBalance,
+		error,
+	)
+
 	// ValidatorBalancesByIndexAndEpochRange fetches the validator balances for the given validators and epoch range.
 	// Ranges are inclusive of start and exclusive of end i.e. a request with startEpoch 2 and endEpoch 4 will provide
 	// balances for epochs 2 and 3.

--- a/services/summarizer/standard/epoch.go
+++ b/services/summarizer/standard/epoch.go
@@ -138,7 +138,6 @@ func (s *Service) validatorSummaryStatsForEpoch(ctx context.Context,
 			activeValidators[i] = true
 		case validator.ExitEpoch == epoch:
 			summary.ExitingValidators++
-			activeValidators[i] = false
 		case validator.ActivationEpoch <= epoch &&
 			validator.ExitEpoch > epoch:
 			summary.ActiveValidators++
@@ -147,7 +146,6 @@ func (s *Service) validatorSummaryStatsForEpoch(ctx context.Context,
 			validator.ActivationEpoch != s.farFutureEpoch &&
 			validator.ActivationEpoch > epoch:
 			summary.ActivationQueueLength++
-			activeValidators[i] = false
 		}
 	}
 	return activeValidators, nil


### PR DESCRIPTION
The epoch summarizer runs a select on the `t_validator_balances` table
with a filter like `f_validator_index = ANY(ARRAY[...])` where the array
lists all active validators (~400k at this time). This is taking a
long time to complete.

To speed things up, rather than pass this huge array in the query,
fetch all rows and do the filtering in chaind.

On my setup I'm seeing epoch summaries computed in few seconds (vs
several minutes previously).

fixes #49 