### PR TITLE
Ensure activity semaphore for beacon committees.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ dev:
   - add configurable database connection pool size
   - separate read-only and read-write transactions internally
   - share activity semaphore between blocks and finalizer modules
+  - ensure only a single beacon committees update can be run at any time
+  - optimise caching of beacon committees during block processing (thanks to @ariskk)
 
 0.6.10
   - avoid crash with uninitialised metrics

--- a/services/beaconcommittees/standard/handler.go
+++ b/services/beaconcommittees/standard/handler.go
@@ -58,6 +58,8 @@ func (s *Service) OnBeaconChainHeadUpdated(
 	s.activitySem.Release(1)
 }
 
+// updateBeaconCommitteesForEpoch sets the beacon committee information for the given epoch.
+// This assumes that a database transaction is already in progress.
 func (s *Service) updateBeaconCommitteesForEpoch(ctx context.Context, epoch phase0.Epoch) error {
 	log.Trace().Uint64("epoch", uint64(epoch)).Msg("Updating beacon committees")
 

--- a/services/beaconcommittees/standard/metadata.go
+++ b/services/beaconcommittees/standard/metadata.go
@@ -23,8 +23,7 @@ import (
 
 // metadata stored about this service.
 type metadata struct {
-	LatestEpoch  phase0.Epoch   `json:"latest_epoch"`
-	MissedEpochs []phase0.Epoch `json:"missed_epochs,omitempty"`
+	LatestEpoch phase0.Epoch `json:"latest_epoch"`
 }
 
 // metadataKey is the key for the metadata.


### PR DESCRIPTION
Beacon committees did not obtain the semaphore during initial catchup, leading to the possibility of multiple handlers running at once.  This ensures the sempahore is obtained both at startup and for events.