### PR TITLE
Update transactionbyhash.go

### DIFF
--- a/services/eth1deposits/getlogs/transactionbyhash.go
+++ b/services/eth1deposits/getlogs/transactionbyhash.go
@@ -49,6 +49,9 @@ func (s *Service) transactionByHash(ctx context.Context, txHash []byte) (*transa
 	if err := json.NewDecoder(respBodyReader).Decode(&response); err != nil {
 		return nil, errors.Wrap(err, "invalid response")
 	}
+	if response.Result == nil {
+		return nil, errors.Wrap(err, "invalid response")
+	}
 
 	return response.Result, nil
 }


### PR DESCRIPTION
Check for invalid (empty) response to eth_getTransactionByHash.

Fix #55 