### PR TITLE
Avoid crash on missing execution tx.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ dev:
   - ensure only a single beacon committees update can be run at any time
   - optimize caching of beacon committees during block processing (thanks to @ariskk)
   - optimize fetching of validator balances when calculating epoch summaries (thanks to @henridf)
+  - avoid crash when execution node does not return transaction for which it supplied a log entry
 
 0.6.10
   - avoid crash with uninitialised metrics

--- a/services/eth1deposits/getlogs/handler.go
+++ b/services/eth1deposits/getlogs/handler.go
@@ -97,15 +97,15 @@ func (s *Service) handleMissed(ctx context.Context, md *metadata) {
 			failed++
 			cancel()
 			continue
-		} else {
-			log.Trace().Msg("Updated block")
-			// Remove this from the list of missed blocks.
-			missedBlocks := make([]uint64, len(md.MissedBlocks)-1)
-			copy(missedBlocks[:failed], md.MissedBlocks[:failed])
-			copy(missedBlocks[failed:], md.MissedBlocks[i+1:])
-			md.MissedBlocks = missedBlocks
-			i--
 		}
+
+		log.Trace().Msg("Updated block")
+		// Remove this from the list of missed blocks.
+		missedBlocks := make([]uint64, len(md.MissedBlocks)-1)
+		copy(missedBlocks[:failed], md.MissedBlocks[:failed])
+		copy(missedBlocks[failed:], md.MissedBlocks[i+1:])
+		md.MissedBlocks = missedBlocks
+		i--
 
 		if err := s.setMetadata(ctx, md); err != nil {
 			log.Error().Err(err).Msg("Failed to set metadata")

--- a/services/eth1deposits/getlogs/handler.go
+++ b/services/eth1deposits/getlogs/handler.go
@@ -16,6 +16,7 @@ package getlogs
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -44,6 +45,10 @@ func (s *Service) handleBlocks(ctx context.Context, startBlock uint64, endBlock 
 		if err != nil {
 			cancel()
 			return errors.Wrap(err, "failed to obtain transaction from transaction hash")
+		}
+		if tx == nil {
+			cancel()
+			return fmt.Errorf("no transaction returned for hash %#x", logEntry.TransactionHash)
 		}
 		receipt, err := s.transactionReceiptByHash(ctx, logEntry.TransactionHash)
 		if err != nil {


### PR DESCRIPTION
Avoid crash when execution node does not return transaction for which it supplied a log entry.

Fixes #55.