### PR TITLE
Check and warn schema version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 0.6.15:
   - catch edge case where summarizer may not include all attestations first time around
+  - warn if running against a newer version of the database schema
 
 0.6.14:
   - avoid crash if no response is given to a 'eth_getBlockByHash' call

--- a/services/chaindb/postgresql/parameters.go
+++ b/services/chaindb/postgresql/parameters.go
@@ -117,7 +117,8 @@ func WithMaxConnections(maxConnections uint) Parameter {
 // parseAndCheckParameters parses and checks parameters to ensure that mandatory parameters are present and correct.
 func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	parameters := parameters{
-		logLevel: zerolog.GlobalLevel(),
+		logLevel:       zerolog.GlobalLevel(),
+		maxConnections: 16,
 	}
 	for _, p := range params {
 		if params != nil {

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -113,6 +113,10 @@ func (s *Service) Upgrade(ctx context.Context) (bool, error) {
 		// Nothing to do.
 		return false, nil
 	}
+	if version > currentVersion {
+		log.Warn().Msg("This release is running an older version than that in the database, please upgrade to the latest release")
+		return false, nil
+	}
 
 	ctx, cancel, err := s.BeginTx(ctx)
 	if err != nil {
@@ -994,6 +998,7 @@ CREATE TABLE t_deposits (
  ,f_amount                 BIGINT NOT NULL
 );
 CREATE UNIQUE INDEX i_deposits_1 ON t_deposits(f_inclusion_slot,f_inclusion_block_root,f_inclusion_index);
+CREATE INDEX i_deposits_2 ON t_deposits(f_validator_pubkey,f_inclusion_slot);
 
 -- t_eth1_deposits stores information about each Ethereum 1 deposit that has occurred for the deposit contract.
 CREATE TABLE t_eth1_deposits (


### PR DESCRIPTION
If the in-database schema version is ahead of the version the code expects then print a warning.