### PR TITLE
update Dockerfile to utilize go 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-bullseye as builder
+FROM golang:1.18-bullseye as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
This seemingly solves for https://github.com/wealdtech/chaind/issues/69