### PR TITLE
Add history of validator's withdrawal credentials

### DIFF
--- a/services/chaindb/postgresql/blstoexecutionchanges.go
+++ b/services/chaindb/postgresql/blstoexecutionchanges.go
@@ -48,7 +48,7 @@ func (s *Service) setBLSToExecutionChanges(ctx context.Context, block *chaindb.B
 INSERT INTO t_block_bls_to_execution_changes(f_block_root
                                             ,f_block_number
                                             ,f_index
-											,f_validator_index
+                                            ,f_validator_index
                                             ,f_from_bls_pubkey
                                             ,f_to_execution_address
                                             )
@@ -96,7 +96,7 @@ func (s *Service) BLSToExecutionChanges(ctx context.Context, filter *chaindb.BLS
 SELECT f_block_root
       ,f_block_number
       ,f_index
-	  ,f_validator_index
+      ,f_validator_index
       ,f_from_bls_pubkey
       ,f_to_execution_address
 FROM t_block_bls_to_execution_changes`)

--- a/services/chaindb/postgresql/blstoexecutionchanges.go
+++ b/services/chaindb/postgresql/blstoexecutionchanges.go
@@ -52,7 +52,7 @@ INSERT INTO t_block_bls_to_execution_changes(f_block_root
                                             ,f_from_bls_pubkey
                                             ,f_to_execution_address
                                             )
-VALUES($1,$2,$3,$4,$5)
+VALUES($1,$2,$3,$4,$5,$6)
 ON CONFLICT (f_block_root,f_block_number,f_index) DO
 UPDATE
 SET f_validator_index = excluded.f_validator_index 

--- a/services/chaindb/postgresql/blstoexecutionchanges.go
+++ b/services/chaindb/postgresql/blstoexecutionchanges.go
@@ -48,18 +48,21 @@ func (s *Service) setBLSToExecutionChanges(ctx context.Context, block *chaindb.B
 INSERT INTO t_block_bls_to_execution_changes(f_block_root
                                             ,f_block_number
                                             ,f_index
+											,f_validator_index
                                             ,f_from_bls_pubkey
                                             ,f_to_execution_address
                                             )
 VALUES($1,$2,$3,$4,$5)
 ON CONFLICT (f_block_root,f_block_number,f_index) DO
 UPDATE
-SET f_from_bls_pubkey = excluded.f_from_bls_pubkey
+SET f_validator_index = excluded.f_validator_index 
+   ,f_from_bls_pubkey = excluded.f_from_bls_pubkey
    ,f_to_execution_address = excluded.f_to_execution_address
 `,
 			change.InclusionBlockRoot[:],
 			change.InclusionSlot,
 			change.InclusionIndex,
+			change.ValidatorIndex,
 			change.FromBLSPubKey[:],
 			change.ToExecutionAddress[:],
 		); err != nil {
@@ -93,7 +96,8 @@ func (s *Service) BLSToExecutionChanges(ctx context.Context, filter *chaindb.BLS
 SELECT f_block_root
       ,f_block_number
       ,f_index
-      ,f_from_blS_pubkey
+	  ,f_validator_index
+      ,f_from_bls_pubkey
       ,f_to_execution_address
 FROM t_block_bls_to_execution_changes`)
 

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -1544,31 +1544,9 @@ func recreateValidators(ctx context.Context, s *Service) error {
 	}
 
 	if _, err := tx.Exec(ctx, `
-CREATE TABLE t_validators (
-  f_public_key                   BYTEA NOT NULL
- ,f_index                        BIGINT NOT NULL
- ,f_slashed                      BOOLEAN NOT NULL
- ,f_activation_eligibility_epoch BIGINT
- ,f_activation_epoch             BIGINT
- ,f_exit_epoch                   BIGINT
- ,f_withdrawable_epoch           BIGINT
- ,f_effective_balance            BIGINT NOT NULL
- ,f_withdrawal_credentials		 BYTEA NOT NULL
-);
+	ALTER TABLE t_validators ADD COLUMN f_withdrawal_credentials BYTEA;
 `); err != nil {
 		return errors.Wrap(err, "failed to create block bls to execution changes table")
-	}
-
-	if _, err := tx.Exec(ctx, `
-CREATE UNIQUE INDEX IF NOT EXISTS i_validators_1 ON t_validators(f_index);
-`); err != nil {
-		return errors.Wrap(err, "failed to create validators index 1")
-	}
-
-	if _, err := tx.Exec(ctx, `
-CREATE UNIQUE INDEX IF NOT EXISTS i_validators_2 ON t_validators(f_public_key);
-`); err != nil {
-		return errors.Wrap(err, "failed to create validators index 2")
 	}
 
 	if _, err := tx.Exec(ctx, `

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -1431,6 +1431,7 @@ CREATE TABLE t_block_bls_to_execution_changes (
   f_block_root            BYTEA   NOT NULL REFERENCES t_blocks(f_root) ON DELETE CASCADE
  ,f_block_number          BIGINT  NOT NULL
  ,f_index                 INTEGER NOT NULL
+ ,f_validator_index       BIGINT  NOT NULL
  ,f_from_bls_pubkey       BYTEA   NOT NULL
  ,f_to_execution_address  BYTEA   NOT NULL
 )
@@ -1454,6 +1455,12 @@ CREATE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_2 ON t_block_bls_to_
 CREATE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_3 ON t_block_bls_to_execution_changes(f_to_execution_address);
 `); err != nil {
 		return errors.Wrap(err, "failed to create block bls to execution changes index 3")
+	}
+
+	if _, err := tx.Exec(ctx, `
+CREATE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_4 ON t_block_bls_to_execution_changes(f_validator_index);
+`); err != nil {
+		return errors.Wrap(err, "failed to create block bls to execution changes index 4")
 	}
 
 	return nil

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -1150,7 +1150,6 @@ CREATE TABLE t_block_bls_to_execution_changes (
 CREATE UNIQUE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_1 ON t_block_bls_to_execution_changes(f_block_root,f_block_number,f_index);
 CREATE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_2 ON t_block_bls_to_execution_changes(f_block_number);
 CREATE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_3 ON t_block_bls_to_execution_changes(f_to_execution_address);
-CREATE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_4 ON t_block_bls_to_execution_changes(f_validator_index);
 
 -- t_block_withdrawals is a subtable for t_blocks.
 -- This data is actually part of the execution payload, but flattened for our purposes.
@@ -1510,12 +1509,6 @@ CREATE INDEX IF NOT EXISTS i_block_withdrawals_2 ON t_block_withdrawals(f_block_
 CREATE INDEX IF NOT EXISTS i_block_withdrawals_3 ON t_block_withdrawals(f_validator_index);
 `); err != nil {
 		return errors.Wrap(err, "failed to create block withdrawals index 3")
-	}
-
-	if _, err := tx.Exec(ctx, `
-CREATE INDEX IF NOT EXISTS i_block_withdrawals_4 ON t_block_withdrawals(f_address);
-`); err != nil {
-		return errors.Wrap(err, "failed to create block withdrawals index 4")
 	}
 
 	return nil

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -851,9 +851,11 @@ CREATE TABLE t_validators (
  ,f_exit_epoch                   BIGINT
  ,f_withdrawable_epoch           BIGINT
  ,f_effective_balance            BIGINT NOT NULL
+ ,f_withdrawal_credentials		 BYTEA NOT NULL
 );
 CREATE UNIQUE INDEX i_validators_1 ON t_validators(f_index);
 CREATE UNIQUE INDEX i_validators_2 ON t_validators(f_public_key);
+CREATE INDEX i_validators_3 ON t_validators(f_withdrawal_credentials);
 
 -- t_blocks contains all blocks proposed by validators.
 -- N.B. it is possible for multiple valid blocks to be proposed in a single slot

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -1136,12 +1136,14 @@ CREATE TABLE t_block_bls_to_execution_changes (
   f_block_root            BYTEA   NOT NULL REFERENCES t_blocks(f_root) ON DELETE CASCADE
  ,f_block_number          BIGINT  NOT NULL
  ,f_index                 INTEGER NOT NULL
+ ,f_validator_index       BIGINT  NOT NULL
  ,f_from_bls_pubkey       BYTEA   NOT NULL
  ,f_to_execution_address  BYTEA   NOT NULL
 );
 CREATE UNIQUE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_1 ON t_block_bls_to_execution_changes(f_block_root,f_block_number,f_index);
 CREATE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_2 ON t_block_bls_to_execution_changes(f_block_number);
 CREATE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_3 ON t_block_bls_to_execution_changes(f_to_execution_address);
+CREATE INDEX IF NOT EXISTS i_block_bls_to_execution_changes_4 ON t_block_bls_to_execution_changes(f_validator_index);
 
 -- t_block_withdrawals is a subtable for t_blocks.
 -- This data is actually part of the execution payload, but flattened for our purposes.

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -105,6 +105,11 @@ var upgrades = map[uint64]*upgrade{
 			recreateForkSchedule,
 		},
 	},
+	12: {
+		funcs: []func(context.Context, *Service) error{
+			recreateValidators,
+		},
+	},
 }
 
 // Upgrade upgrades the database.
@@ -1534,6 +1539,49 @@ CREATE TABLE t_fork_schedule (
 )
 `); err != nil {
 		return errors.Wrap(err, "failed to create fork schedule")
+	}
+
+	return nil
+}
+
+func recreateValidators(ctx context.Context, s *Service) error {
+	tx := s.tx(ctx)
+	if tx == nil {
+		return ErrNoTransaction
+	}
+
+	if _, err := tx.Exec(ctx, `
+CREATE TABLE t_validators (
+  f_public_key                   BYTEA NOT NULL
+ ,f_index                        BIGINT NOT NULL
+ ,f_slashed                      BOOLEAN NOT NULL
+ ,f_activation_eligibility_epoch BIGINT
+ ,f_activation_epoch             BIGINT
+ ,f_exit_epoch                   BIGINT
+ ,f_withdrawable_epoch           BIGINT
+ ,f_effective_balance            BIGINT NOT NULL
+ ,f_withdrawal_credentials		 BYTEA NOT NULL
+);
+`); err != nil {
+		return errors.Wrap(err, "failed to create block bls to execution changes table")
+	}
+
+	if _, err := tx.Exec(ctx, `
+CREATE UNIQUE INDEX IF NOT EXISTS i_validators_1 ON t_validators(f_index);
+`); err != nil {
+		return errors.Wrap(err, "failed to create validators index 1")
+	}
+
+	if _, err := tx.Exec(ctx, `
+CREATE UNIQUE INDEX IF NOT EXISTS i_validators_2 ON t_validators(f_public_key);
+`); err != nil {
+		return errors.Wrap(err, "failed to create validators index 2")
+	}
+
+	if _, err := tx.Exec(ctx, `
+CREATE INDEX IF NOT EXISTS i_validators_3 ON t_validators(f_withdrawal_credentials);
+`); err != nil {
+		return errors.Wrap(err, "failed to create validators index 3")
 	}
 
 	return nil

--- a/services/chaindb/postgresql/upgrader.go
+++ b/services/chaindb/postgresql/upgrader.go
@@ -27,7 +27,7 @@ type schemaMetadata struct {
 	Version uint64 `json:"version"`
 }
 
-var currentVersion = uint64(11)
+var currentVersion = uint64(12)
 
 type upgrade struct {
 	requiresRefetch bool

--- a/services/chaindb/postgresql/validators.go
+++ b/services/chaindb/postgresql/validators.go
@@ -70,7 +70,7 @@ func (s *Service) SetValidator(ctx context.Context, validator *chaindb.Validator
                               ,f_exit_epoch
                               ,f_withdrawable_epoch
                               ,f_effective_balance
-							  ,f_withdrawal_credentials)
+                              ,f_withdrawal_credentials)
       VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9)
       ON CONFLICT (f_index) DO
       UPDATE
@@ -81,7 +81,7 @@ func (s *Service) SetValidator(ctx context.Context, validator *chaindb.Validator
          ,f_exit_epoch = excluded.f_exit_epoch
          ,f_withdrawable_epoch = excluded.f_withdrawable_epoch
          ,f_effective_balance = excluded.f_effective_balance
-		 ,f_withdrawal_credentials = excluded.f_withdrawal_credentials
+         ,f_withdrawal_credentials = excluded.f_withdrawal_credentials
 		 `,
 		validator.PublicKey[:],
 		validator.Index,
@@ -180,7 +180,7 @@ func (s *Service) Validators(ctx context.Context) ([]*chaindb.Validator, error) 
             ,f_exit_epoch
             ,f_withdrawable_epoch
             ,f_effective_balance
-			,f_withdrawal_credentials
+            ,f_withdrawal_credentials
       FROM t_validators
       ORDER BY f_index
 	  `)

--- a/services/chaindb/types.go
+++ b/services/chaindb/types.go
@@ -51,7 +51,7 @@ type Validator struct {
 	ActivationEpoch            phase0.Epoch
 	ExitEpoch                  phase0.Epoch
 	WithdrawableEpoch          phase0.Epoch
-	WithdrawalCredentials      []byte
+	WithdrawalCredentials      [32]byte
 }
 
 // ValidatorBalance holds information about a validator's balance at a given epoch.

--- a/services/chaindb/types.go
+++ b/services/chaindb/types.go
@@ -51,6 +51,7 @@ type Validator struct {
 	ActivationEpoch            phase0.Epoch
 	ExitEpoch                  phase0.Epoch
 	WithdrawableEpoch          phase0.Epoch
+	WithdrawalCredentials      []byte
 }
 
 // ValidatorBalance holds information about a validator's balance at a given epoch.

--- a/services/validators/standard/handler.go
+++ b/services/validators/standard/handler.go
@@ -244,6 +244,9 @@ func needsUpdate(validator *phase0.Validator,
 	if dbValidator.WithdrawableEpoch != validator.WithdrawableEpoch {
 		return true
 	}
+	if !bytes.Equal(dbValidator.WithdrawalCredentials[:], validator.WithdrawalCredentials[:]) {
+		return true
+	}
 
 	return false
 }

--- a/services/validators/standard/handler.go
+++ b/services/validators/standard/handler.go
@@ -120,6 +120,7 @@ func (s *Service) onEpochTransitionValidators(ctx context.Context,
 			ActivationEpoch:            validator.Validator.ActivationEpoch,
 			ExitEpoch:                  validator.Validator.ExitEpoch,
 			WithdrawableEpoch:          validator.Validator.WithdrawableEpoch,
+			WithdrawalCredentials:      validator.Validator.WithdrawalCredentials,
 		}
 		if err := s.validatorsSetter.SetValidator(ctx, dbValidator); err != nil {
 			cancel()


### PR DESCRIPTION
This PR implements the changes proposed in https://github.com/wealdtech/chaind/issues/78#issuecomment-1423810954

We did not do extensive testing of these changes, but they seem to be working fine when indexing zhejiang. Let us know if there's anything we got wrong or that we can improve.