### PR TITLE
failure to open log-file does not show an error

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main2() int {
 		return 1
 	}
 	if err := initLogging(); err != nil {
-		log.Error().Err(err).Msg("Failed to initialise logging")
+		fmt.Fprintf(os.Stderr, "Failed to initialise logging: %v\n", err)
 		return 1
 	}
 


### PR DESCRIPTION
If `OpenFile` inside `initLogging` fails for whatever reason, e.g. Permission Denied, global var `log` remains uninitialized, which makes the error message not to be printed to stdout.