### PR TITLE
Bug: missing flag for lighthouse historic state

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ createdb -E UTF8 --owner=chain chain
 `chaind` supports Teku and Lighthouse beacon nodes.  The current state of obtaining data from beacon nodes is as follows:
 
   - Teku: must be run in [archive mode](https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#data-storage-mode) to allow `chaind` to obtain historical data
-  - Lighthouse: Make sure to run with `--slots-per-restore-point 64`, else fetching historical information will be **very** slow. For more information on the trade off between Freezer DB size and fetching performance, please refer to [Database Configuration](https://lighthouse-book.sigmaprime.io/advanced_database.html) in the Lighthouse Book.
+  - Lighthouse: Make sure to run with `--slots-per-restore-point 64 --reconstruct-historic-states`, else fetching historical information will be **very** slow. For more information on the trade off between Freezer DB size and fetching performance, please refer to [Database Configuration](https://lighthouse-book.sigmaprime.io/advanced_database.html) in the Lighthouse Book.
 
 At current Prysm is not supported due to its lack of Altair-related information in its gRPC and HTTP APIs.  We expect to be able to support Prysm again soon.
 


### PR DESCRIPTION
I think chaind needs lighthouse to be started with the `--reconstruct-historic-states` flag.

Sproul in the lighthouse discord [mentioned](https://discord.com/channels/605577013327167508/605577013331361793/1087537928449831032)
<img width="928" alt="image" src="https://user-images.githubusercontent.com/9342524/226497184-ee78605e-80ab-4908-9994-44f16b50e7ee.png">

Otherwise none of the historic states before the checkpoint slot are ever stored (`--slots-per-restore-point` only affects slots after the checkpoint slot without `--reconstruct-historic-states`).