### PR TITLE
added metric viper flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ eth1deposits:
   # keep track of this itself, however if you wish to start from a different block this
   # can be set.
   # start-block: 500
+metrics:
+  prometheus:
+    # port on which prometheus metrics will be exposed
+    # the endpoint in this example would then be localhost:8041/metrics
+    listen-address: localhost:8041
 ```
 
 ## Support

--- a/main.go
+++ b/main.go
@@ -173,6 +173,7 @@ func fetchConfig() error {
 	pflag.String("eth1deposits.start-block", "", "Ethereum 1 block from which to start fetching deposits")
 	pflag.String("eth1client.address", "", "Address for Ethereum 1 node")
 	pflag.String("chaindb.url", "", "URL for database")
+	pflag.String("metrics.prometheus.listen-address", "", "port to expose prometheus metrics")
 	pflag.Uint("chaindb.max-connections", 16, "maximum number of concurrent database connections")
 	pflag.Parse()
 	if err := viper.BindPFlags(pflag.CommandLine); err != nil {


### PR DESCRIPTION
We need prometheus metrics and realized these were not actually exportable based on the current viper flags.
Not familiar with viper though so I might have misunderstood something.
Also unsure why we need to give it an address instead of just the port number. Isn't it always going to be exposed at localhost:8041?