### PR TITLE
Added ability to disable blobs saving for blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.10.2:
+  - added `blocks.blobs.enable` configuration flag (default: true) to control whether blobs for blocks should be fetched and saved
+
 0.10.1:
   - fix block handlers for fulu block event
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ blocks:
   # refetch will refetch block data from a beacon node even if it has already has a block
   # in its database.
   # refetch: false
+  # blob.enable will fetch and save blobs for block
+  blob:
+    enable: true
 # validators contains configuration for obtaining validator-related information.
 validators:
   enable: true

--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ blocks:
   # refetch will refetch block data from a beacon node even if it has already has a block
   # in its database.
   # refetch: false
-  # blob.enable will fetch and save blobs for block
-  blob:
+  # blobs.enable will fetch and save blobs for block
+  blobs:
     enable: true
 # validators contains configuration for obtaining validator-related information.
 validators:

--- a/chaind.config.docker-compose.yml
+++ b/chaind.config.docker-compose.yml
@@ -33,7 +33,8 @@ blocks:
   # refetch will refetch block data from a beacon node even if it has already has a block
   # in its database.
   # refetch: false
-  blob:
+  # blobs.enable will fetch and save blobs for blocks
+  blobs:
     enable: true
 # validators contains configuration for obtaining validator-related information.
 validators:

--- a/chaind.config.docker-compose.yml
+++ b/chaind.config.docker-compose.yml
@@ -33,6 +33,8 @@ blocks:
   # refetch will refetch block data from a beacon node even if it has already has a block
   # in its database.
   # refetch: false
+  blob:
+    enable: true
 # validators contains configuration for obtaining validator-related information.
 validators:
   enable: true

--- a/main.go
+++ b/main.go
@@ -161,7 +161,7 @@ func fetchConfig() error {
 	pflag.Bool("blocks.enable", true, "Enable fetching of block-related information")
 	pflag.Int32("blocks.start-slot", -1, "Slot from which to start fetching blocks")
 	pflag.Bool("blocks.refetch", false, "Refetch all blocks even if they are already in the database")
-	pflag.Bool("blocks.blob.enable", true, "Enable saving of block-related blobs")
+	pflag.Bool("blocks.blobs.enable", true, "Enable saving of blobs for block-related information")
 	pflag.Bool("finalizer.enable", true, "Enable additional information on receipt of finality checkpoint")
 	pflag.Bool("summarizer.enable", true, "Enable summary information")
 	pflag.Bool("summarizer.epochs.enable", true, "Enable summary information for epochs")
@@ -509,7 +509,7 @@ func startBlocks(
 		standardblocks.WithChainDB(chainDB),
 		standardblocks.WithStartSlot(viper.GetInt64("blocks.start-slot")),
 		standardblocks.WithRefetch(viper.GetBool("blocks.refetch")),
-		standardblocks.WithBlobEnable(viper.GetBool("blocks.blob.enable")),
+		standardblocks.WithBlobsSaving(viper.GetBool("blocks.blobs.enable")),
 		standardblocks.WithActivitySem(activitySem),
 	)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -161,6 +161,7 @@ func fetchConfig() error {
 	pflag.Bool("blocks.enable", true, "Enable fetching of block-related information")
 	pflag.Int32("blocks.start-slot", -1, "Slot from which to start fetching blocks")
 	pflag.Bool("blocks.refetch", false, "Refetch all blocks even if they are already in the database")
+	pflag.Bool("blocks.blob.enable", true, "Enable saving of block-related blobs")
 	pflag.Bool("finalizer.enable", true, "Enable additional information on receipt of finality checkpoint")
 	pflag.Bool("summarizer.enable", true, "Enable summary information")
 	pflag.Bool("summarizer.epochs.enable", true, "Enable summary information for epochs")
@@ -508,6 +509,7 @@ func startBlocks(
 		standardblocks.WithChainDB(chainDB),
 		standardblocks.WithStartSlot(viper.GetInt64("blocks.start-slot")),
 		standardblocks.WithRefetch(viper.GetBool("blocks.refetch")),
+		standardblocks.WithBlobEnable(viper.GetBool("blocks.blob.enable")),
 		standardblocks.WithActivitySem(activitySem),
 	)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "0.10.1"
+var ReleaseVersion = "0.10.2"
 
 func main() {
 	os.Exit(main2())

--- a/services/blocks/standard/handler.go
+++ b/services/blocks/standard/handler.go
@@ -714,6 +714,10 @@ func (s *Service) updateBlobSidecarsForBlock(ctx context.Context,
 	ctx, span := otel.Tracer("wealdtech.chaind.services.blocks.standard").Start(ctx, "updateBlobSidecarsForBlock")
 	defer span.End()
 
+	if !s.blobEnable {
+		return nil
+	}
+
 	response, err := s.eth2Client.(eth2client.BlobSidecarsProvider).BlobSidecars(ctx, &api.BlobSidecarsOpts{
 		Block: blockRoot.String(),
 	})

--- a/services/blocks/standard/handler.go
+++ b/services/blocks/standard/handler.go
@@ -711,7 +711,7 @@ func (s *Service) updateSyncAggregateForBlock(ctx context.Context,
 func (s *Service) updateBlobSidecarsForBlock(ctx context.Context,
 	blockRoot phase0.Root,
 ) error {
-    if !s.blobsSaving {
+	if !s.blobsSaving {
 		return nil
 	}
 

--- a/services/blocks/standard/handler.go
+++ b/services/blocks/standard/handler.go
@@ -714,7 +714,7 @@ func (s *Service) updateBlobSidecarsForBlock(ctx context.Context,
 	ctx, span := otel.Tracer("wealdtech.chaind.services.blocks.standard").Start(ctx, "updateBlobSidecarsForBlock")
 	defer span.End()
 
-	if !s.blobEnable {
+	if !s.blobsSaving {
 		return nil
 	}
 

--- a/services/blocks/standard/handler.go
+++ b/services/blocks/standard/handler.go
@@ -711,12 +711,12 @@ func (s *Service) updateSyncAggregateForBlock(ctx context.Context,
 func (s *Service) updateBlobSidecarsForBlock(ctx context.Context,
 	blockRoot phase0.Root,
 ) error {
-	ctx, span := otel.Tracer("wealdtech.chaind.services.blocks.standard").Start(ctx, "updateBlobSidecarsForBlock")
-	defer span.End()
-
-	if !s.blobsSaving {
+    if !s.blobsSaving {
 		return nil
 	}
+
+	ctx, span := otel.Tracer("wealdtech.chaind.services.blocks.standard").Start(ctx, "updateBlobSidecarsForBlock")
+	defer span.End()
 
 	response, err := s.eth2Client.(eth2client.BlobSidecarsProvider).BlobSidecars(ctx, &api.BlobSidecarsOpts{
 		Block: blockRoot.String(),

--- a/services/blocks/standard/parameters.go
+++ b/services/blocks/standard/parameters.go
@@ -32,7 +32,7 @@ type parameters struct {
 	chainTime   chaintime.Service
 	startSlot   int64
 	refetch     bool
-	blobEnable  bool
+	blobsSaving bool
 	activitySem *semaphore.Weighted
 }
 
@@ -96,10 +96,10 @@ func WithRefetch(refetch bool) Parameter {
 	})
 }
 
-// WithBlobEnable sets the blobEnable flag for this module.
-func WithBlobEnable(blobEnable bool) Parameter {
+// WithBlobsSaving sets the blobsSaving flag for this module.
+func WithBlobsSaving(blobsSaving bool) Parameter {
 	return parameterFunc(func(p *parameters) {
-		p.blobEnable = blobEnable
+		p.blobsSaving = blobsSaving
 	})
 }
 

--- a/services/blocks/standard/parameters.go
+++ b/services/blocks/standard/parameters.go
@@ -32,6 +32,7 @@ type parameters struct {
 	chainTime   chaintime.Service
 	startSlot   int64
 	refetch     bool
+	blobEnable  bool
 	activitySem *semaphore.Weighted
 }
 
@@ -92,6 +93,13 @@ func WithStartSlot(startSlot int64) Parameter {
 func WithRefetch(refetch bool) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.refetch = refetch
+	})
+}
+
+// WithBlobEnable sets the blobEnable flag for this module.
+func WithBlobEnable(blobEnable bool) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.blobEnable = blobEnable
 	})
 }
 

--- a/services/blocks/standard/service.go
+++ b/services/blocks/standard/service.go
@@ -47,7 +47,7 @@ type Service struct {
 	consolidationRequestsSetter chaindb.ConsolidationRequestsSetter
 	chainTime                   chaintime.Service
 	refetch                     bool
-	blobEnable                  bool
+	blobsSaving                 bool
 	lastHandledBlockRoot        phase0.Root
 	activitySem                 *semaphore.Weighted
 	syncCommittees              map[uint64]*chaindb.SyncCommittee
@@ -153,13 +153,13 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		consolidationRequestsSetter: consolidationRequestsSetter,
 		chainTime:                   parameters.chainTime,
 		refetch:                     parameters.refetch,
-		blobEnable:                  parameters.blobEnable,
+		blobsSaving:                 parameters.blobsSaving,
 		activitySem:                 parameters.activitySem,
 		syncCommittees:              make(map[uint64]*chaindb.SyncCommittee),
 	}
 
-	log.Info().
-		Bool("blobEnable", parameters.blobEnable).
+	log.Trace().
+		Bool("blobsSaving", parameters.blobsSaving).
 		Bool("refetch", parameters.refetch).
 		Int64("startSlot", parameters.startSlot).
 		Msg("Blocks Service initialized")

--- a/services/blocks/standard/service.go
+++ b/services/blocks/standard/service.go
@@ -47,6 +47,7 @@ type Service struct {
 	consolidationRequestsSetter chaindb.ConsolidationRequestsSetter
 	chainTime                   chaintime.Service
 	refetch                     bool
+	blobEnable                  bool
 	lastHandledBlockRoot        phase0.Root
 	activitySem                 *semaphore.Weighted
 	syncCommittees              map[uint64]*chaindb.SyncCommittee
@@ -152,10 +153,16 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		consolidationRequestsSetter: consolidationRequestsSetter,
 		chainTime:                   parameters.chainTime,
 		refetch:                     parameters.refetch,
+		blobEnable:                  parameters.blobEnable,
 		activitySem:                 parameters.activitySem,
 		syncCommittees:              make(map[uint64]*chaindb.SyncCommittee),
 	}
 
+	log.Info().
+		Bool("blobEnable", parameters.blobEnable).
+		Bool("refetch", parameters.refetch).
+		Int64("startSlot", parameters.startSlot).
+		Msg("Blocks Service initialized")
 	// Note the current highest processed block for the monitor.
 	md, err := s.getMetadata(ctx)
 	if err != nil {


### PR DESCRIPTION
## What was done

Added support for disabling blob sidecars saving in the blocks service.

### Changes:
- **Configuration**: Added `blocks.blobs.enable` configuration flag (default: `true`) to control whether blob sidecars should be fetched and saved
- **CLI Support**: Added `--blocks.blob.enable` flag to command-line parameters
- **ENV Variable**: Added `CHAIND_BLOCKS_BLOB_ENABLE` variable to manage  `--blocks.blob.enable` flag
- **Service Implementation**:
  - Added `blobEnable` parameter to the Service structure
  - Implemented early return in `updateBlobSidecarsForBlock()` when blob saving is disabled, skipping unnecessary API calls
  - Added initialization logging to display blob enable status

### Benefits:
- Allows operators to disable blob saving for resource optimization when they are not needed

### Testing
- Build is working 
<img width="1252" height="778" alt="image" src="https://github.com/user-attachments/assets/009b3f0a-36e7-460a-9ab4-f67c0a31889d" />
- Container is running
<img width="1282" height="262" alt="image" src="https://github.com/user-attachments/assets/e3c04f45-17ed-4208-a0da-1c64d2372f69" />

